### PR TITLE
Handle snippet with blank accountid DE-3132

### DIFF
--- a/Block/View/Element/Template.php
+++ b/Block/View/Element/Template.php
@@ -82,6 +82,15 @@ class Template extends \Magento\Framework\View\Element\Template
         return $this->_storeManager->getStore();
     }
 
+    public function getAccountId()
+    {
+        return $this->getConfig()->getValue(
+            'dripconnect_general/api_settings/account_id',
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            $this->getStore()->getId()
+        );
+    }
+
     /**
      * @return bool
      */

--- a/view/frontend/templates/drip/footer_js.phtml
+++ b/view/frontend/templates/drip/footer_js.phtml
@@ -1,5 +1,5 @@
 <?php if ($block->isModuleActive()) : ?>
-    <?php $accountId = $block->getConfig()->getValue('dripconnect_general/api_settings/account_id'); ?>
+    <?php $accountId = $block->getAccountId(); ?>
     <?php if (!empty($accountId)) : ?>
         <!-- Drip -->
         <script type="text/javascript">


### PR DESCRIPTION
https://dripcom.atlassian.net/browse/DE-3132

If the store view has the module disabled, the snippet won't show at all. However, customers sometimes will enable the plugin and not add an account ID. This creates a somewhat confusing situation, where a snippet is added but without the account ID. Instead of doing so, we add an HTML comment to elucidate the situation.

This also fixes a bug where it only looks at the global configuration instead of the store configuration.