### PR TITLE
Blank event email submission de 3129

### DIFF
--- a/Cron/Customers.php
+++ b/Cron/Customers.php
@@ -157,7 +157,7 @@ class Customers
             $batchEvents = array();
             foreach ($collection as $subscriber) {
                 $email = $subscriber->getSubscriberEmail();
-                if (empty($email)) {
+                if (!$this->connectHelper->isEmailValid($email)) {
                     $this->logger->notice("Skipping newsletter subscriber event during sync due to blank email");
                     continue;
                 }

--- a/Helper/Customer.php
+++ b/Helper/Customer.php
@@ -258,7 +258,7 @@ class Customer extends \Magento\Framework\App\Helper\AbstractHelper
     public function proceedAccountNew($customer)
     {
         $email = $customer->getEmail();
-        if (empty($email)) {
+        if (!$this->connectHelper->isEmailValid($email)) {
             // TODO: Log this.
             // $this->logger->notice("Skipping customer account create due to blank email");
             return;
@@ -308,7 +308,7 @@ class Customer extends \Magento\Framework\App\Helper\AbstractHelper
     public function proceedGuestSubscriberNew($subscriber)
     {
         $email = $subscriber->getSubscriberEmail();
-        if (empty($email)) {
+        if (!$this->connectHelper->isEmailValid($email)) {
             // TODO: Log this.
             // $this->logger->notice("Skipping guest subscriber create due to blank email");
             return;


### PR DESCRIPTION
Newsletter events get sent and rejected with blank and invalid emails. Let's just skip them.