### PR TITLE
Product Variant ID fixes

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -263,7 +263,7 @@ class Order extends \Magento\Framework\App\Helper\AbstractHelper
     {
         $childItems = array();
         foreach ($order->getAllItems() as $item) {
-            if (!$item->getParentItemId()) { continue; }
+            if ($item->getParentItemId() === null) { continue; }
             $childItems[$item->getParentItemId()] = $item;
         }
 

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -240,11 +240,11 @@ class Order extends \Magento\Framework\App\Helper\AbstractHelper
             'first_name' => (string) $address->getFirstname(),
             'last_name' => (string) $address->getLastname(),
             'company' => (string) $address->getCompany(),
-            'address_1' => (string) $address->getStreet1(),
-            'address_2' => (string) $address->getStreet2(),
+            'address_1' => (string) $address->getStreetLine(1),
+            'address_2' => (string) $address->getStreetLine(2),
             'city' => (string) $address->getCity(),
             'state' => (string) $address->getRegion(),
-            'zip' => (string) $address->getPostcode(),
+            'postal_code' => (string) $address->getPostcode(),
             'country' => (string) $address->getCountryId(),
             'phone' => (string) $address->getTelephone(),
             'email' => (string) $address->getEmail(),
@@ -261,10 +261,22 @@ class Order extends \Magento\Framework\App\Helper\AbstractHelper
      */
     protected function getOrderItemsData($order, $isRefund = false)
     {
-        $data = [];
+        $childItems = array();
         foreach ($order->getAllItems() as $item) {
+            if (!$item->getParentItemId()) { continue; }
+            $childItems[$item->getParentItemId()] = $item;
+        }
+
+        $data = [];
+        foreach ($order->getAllVisibleItems() as $item) {
+            $productVariantItem = $item;
+            if ($item->getProductType() === 'configurable' && \array_key_exists($item->getId(), $childItems)) {
+                $productVariantItem = $childItems[$item->getId()];
+            }
+
             $group = [
                 'product_id' => (string) $item->getProductId(),
+                'product_variant_id' => (string) $productVariantItem->getProductId(),
                 'sku' => (string) $item->getSku(),
                 'name' => (string) $item->getName(),
                 'quantity' => (float) $item->getQtyOrdered(),
@@ -277,8 +289,9 @@ class Order extends \Magento\Framework\App\Helper\AbstractHelper
             ];
             if ($item->getProduct() !== null) {
                 $product = $this->catalogProductFactory->create()->load($item->getProductId());
-                $categories = explode(',', $this->connectHelper->getProductCategoryNames($product));
-                if (empty($categories)) {
+                $productCategoryNames = $this->connectHelper->getProductCategoryNames($product);
+                $categories = explode(',', $productCategoryNames);
+                if ($productCategoryNames === '' || empty($categories)) {
                     $categories = [];
                 }
                 $group['categories'] = $categories;

--- a/Helper/Quote.php
+++ b/Helper/Quote.php
@@ -184,11 +184,11 @@ class Quote extends \Magento\Framework\App\Helper\AbstractHelper
     {
         $childItems = array();
         foreach ($quote->getAllItems() as $item) {
-            if (!$item->getParentItemId()) { continue; }
+            if ($item->getParentItemId() === null) { continue; }
             $childItems[$item->getParentItemId()] = $item;
         }
 
-        $data =  [];
+        $data = [];
         foreach ($quote->getAllVisibleItems() as $item) {
             $product = $this->catalogProductFactory->create()->load($item->getProduct()->getId());
 

--- a/Observer/Base.php
+++ b/Observer/Base.php
@@ -39,11 +39,11 @@ abstract class Base implements \Magento\Framework\Event\ObserverInterface
         $myClass = get_class($this);
         $this->logger->info("Observer triggered: {$myClass}");
 
-        // try {
+        try {
             $this->executeWhenEnabled($observer);
-        // } catch (\Exception $e) {
+        } catch (\Exception $e) {
             // We should never blow up a customer's site due to bugs in our code.
-            // $this->logger->critical($e);
-        // }
+            $this->logger->critical($e);
+        }
     }
 }

--- a/Observer/Base.php
+++ b/Observer/Base.php
@@ -39,11 +39,11 @@ abstract class Base implements \Magento\Framework\Event\ObserverInterface
         $myClass = get_class($this);
         $this->logger->info("Observer triggered: {$myClass}");
 
-        try {
+        // try {
             $this->executeWhenEnabled($observer);
-        } catch (\Exception $e) {
+        // } catch (\Exception $e) {
             // We should never blow up a customer's site due to bugs in our code.
-            $this->logger->critical($e);
-        }
+            // $this->logger->critical($e);
+        // }
     }
 }

--- a/devtools_m2/Dockerfile
+++ b/devtools_m2/Dockerfile
@@ -32,3 +32,6 @@ RUN cd /var/www/html/magento && composer install
 
 USER root
 CMD [ "/usr/sbin/apache2", "-DFOREGROUND" ]
+
+# Make life a little nicer when we log into the container.
+WORKDIR /var/www/html/magento

--- a/devtools_m2/cypress.json
+++ b/devtools_m2/cypress.json
@@ -1,5 +1,10 @@
 {
   "projectId": "35f86d",
   "ignoreTestFiles": "*.js",
-  "baseUrl": "http://main.magento.localhost:3006"
+  "baseUrl": "http://main.magento.localhost:3006",
+
+  "defaultCommandTimeout": 10000,
+  "pageLoadTimeout": 100000,
+  "requestTimeout": 10000,
+  "responseTimeout": 10000
 }

--- a/devtools_m2/cypress/integration/ClientJs.feature
+++ b/devtools_m2/cypress/integration/ClientJs.feature
@@ -5,7 +5,7 @@ Feature: Client.JS
   Scenario: When a site has Client.js enabled
     Given I am logged into the admin interface
       And I have set up a multi-store configuration
-      And I have configured Drip to be enabled for site1
+      And I have configured Drip to be enabled for 'site1'
     When I open the site1 homepage
     Then clientjs is inserted
     When I open the main homepage

--- a/devtools_m2/cypress/integration/ClientJs.feature
+++ b/devtools_m2/cypress/integration/ClientJs.feature
@@ -6,7 +6,7 @@ Feature: Client.JS
     Given I am logged into the admin interface
       And I have set up a multi-store configuration
       And I have configured Drip to be enabled for 'site1'
-    When I open the site1 homepage
+    When I open the 'site1' homepage
     Then clientjs is inserted
-    When I open the main homepage
+    When I open the 'main' homepage
     Then clientjs is not inserted

--- a/devtools_m2/cypress/integration/CustomerCartInteractions.feature
+++ b/devtools_m2/cypress/integration/CustomerCartInteractions.feature
@@ -5,7 +5,7 @@ Feature: Customer Cart Interactions
   Scenario: A customer adds a simple product to their cart
     Given I am logged into the admin interface
       And I have configured Drip to be enabled for 'main'
-      And I have configured a simple widget
+    Given I have configured a simple widget
     When I open the 'main' homepage
       And I create an account
       And I add a 'simple' widget to my cart
@@ -13,6 +13,7 @@ Feature: Customer Cart Interactions
     When I check out
     Then A simple order event should be sent to Drip
 
+  @focus
   Scenario: A customer adds a configurable product to their cart and sees data about the sub-item
     Given I am logged into the admin interface
       And I have configured Drip to be enabled for 'main'

--- a/devtools_m2/cypress/integration/CustomerCartInteractions.feature
+++ b/devtools_m2/cypress/integration/CustomerCartInteractions.feature
@@ -13,7 +13,6 @@ Feature: Customer Cart Interactions
     When I check out
     Then A simple order event should be sent to Drip
 
-  @focus
   Scenario: A customer adds a configurable product to their cart and sees data about the sub-item
     Given I am logged into the admin interface
       And I have configured Drip to be enabled for 'main'
@@ -49,6 +48,7 @@ Feature: Customer Cart Interactions
   # Note that we skip a test for virtual and downloadable products since they
   # are essentially the same as simple products, as far as we are concerned.
 
+  @focus
   Scenario: A customer adds a bundle product to their cart and sees the parent item
     Given I am logged into the admin interface
       And I have configured Drip to be enabled for 'main'

--- a/devtools_m2/cypress/integration/CustomerCartInteractions.feature
+++ b/devtools_m2/cypress/integration/CustomerCartInteractions.feature
@@ -48,7 +48,6 @@ Feature: Customer Cart Interactions
   # Note that we skip a test for virtual and downloadable products since they
   # are essentially the same as simple products, as far as we are concerned.
 
-  @focus
   Scenario: A customer adds a bundle product to their cart and sees the parent item
     Given I am logged into the admin interface
       And I have configured Drip to be enabled for 'main'

--- a/devtools_m2/cypress/integration/CustomerCartInteractions.feature
+++ b/devtools_m2/cypress/integration/CustomerCartInteractions.feature
@@ -1,13 +1,60 @@
 Feature: Customer Cart Interactions
 
-  I want to send cart events to Drip when a customer interacts with their cart.
+  I want to send cart and order events to Drip when a customer interacts with their cart.
 
-  Scenario: When a customer adds something to their cart
+  Scenario: A customer adds a simple product to their cart
     Given I am logged into the admin interface
-      And I have set up a multi-store configuration
-      And I have configured Drip to be enabled for main
-      And I have configured a widget
-    When I open the main homepage
+      And I have configured Drip to be enabled for 'main'
+      And I have configured a simple widget
+    When I open the 'main' homepage
       And I create an account
-      And I add something to my cart
-    Then A cart event should be sent to Drip
+      And I add a 'simple' widget to my cart
+    Then A simple cart event should be sent to Drip
+    When I check out
+    Then A simple order event should be sent to Drip
+
+  Scenario: A customer adds a configurable product to their cart and sees data about the sub-item
+    Given I am logged into the admin interface
+      And I have configured Drip to be enabled for 'main'
+      And I have configured a configurable widget
+    When I open the 'main' homepage
+      And I create an account
+      And I add a 'configurable' widget to my cart
+    Then A configurable cart event should be sent to Drip
+    When I check out
+    Then A configurable order event should be sent to Drip
+
+  Scenario: A customer adds several configurable products to their cart and sees data about the sub-items
+    Given I am logged into the admin interface
+      And I have configured Drip to be enabled for 'main'
+      And I have configured a configurable widget
+    When I open the 'main' homepage
+      And I create an account
+      And I add a 'configurable' widget to my cart
+      And I add a different 'configurable' widget to my cart
+    Then Configurable cart events should be sent to Drip
+
+  Scenario: A customer adds a grouped product to their cart and sees all the individual items
+    Given I am logged into the admin interface
+      And I have configured Drip to be enabled for 'main'
+      And I have configured a grouped widget
+    When I open the 'main' homepage
+      And I create an account
+      And I add a 'grouped' widget to my cart
+    Then A grouped cart event should be sent to Drip
+    When I check out
+    Then A grouped order event should be sent to Drip
+
+  # Note that we skip a test for virtual and downloadable products since they
+  # are essentially the same as simple products, as far as we are concerned.
+
+  Scenario: A customer adds a bundle product to their cart and sees the parent item
+    Given I am logged into the admin interface
+      And I have configured Drip to be enabled for 'main'
+      And I have configured a bundle widget
+    When I open the 'main' homepage
+      And I create an account
+      And I add a 'bundle' widget to my cart
+    Then A bundle cart event should be sent to Drip
+    When I check out
+    Then A bundle order event should be sent to Drip

--- a/devtools_m2/cypress/integration/CustomerCartInteractions/steps.js
+++ b/devtools_m2/cypress/integration/CustomerCartInteractions/steps.js
@@ -18,6 +18,7 @@ When('I create an account', function() {
 When('I add a {string} widget to my cart', function(type) {
   cy.server()
   cy.route('POST', 'checkout/cart/add/**').as('addToCartRequest')
+  cy.route('GET', '/customer/section/load/**').as('cartSectionLoading')
   cy.visit(`/widget-1.html`)
   switch (type) {
     case 'configurable':
@@ -28,6 +29,13 @@ When('I add a {string} widget to my cart', function(type) {
       cy.get('#product_addtocart_form input[name="super_group[3]"]').clear().type('1')
       break;
     case 'bundle':
+      // There are four of these guys, so we wait for all of them...
+      // The one we care about is http://main.magento.localhost:3006/customer/section/load/?sections=cart,customer,messages,compare-products,product_data_storage,captcha&force_new_section_timestamp=false&_=1571690556626
+      // but it seems like we can't match on query params.
+      cy.wait('@cartSectionLoading')
+      cy.wait('@cartSectionLoading')
+      cy.wait('@cartSectionLoading')
+      cy.wait('@cartSectionLoading')
       cy.contains('Customize and Add to Cart').click()
       break;
     case 'simple':

--- a/devtools_m2/cypress/integration/CustomerCartInteractions/steps.js
+++ b/devtools_m2/cypress/integration/CustomerCartInteractions/steps.js
@@ -27,14 +27,16 @@ When('I add a {string} widget to my cart', function(type) {
       cy.get('#product_addtocart_form input[name="super_group[2]"]').clear().type('1')
       cy.get('#product_addtocart_form input[name="super_group[3]"]').clear().type('1')
       break;
+    case 'bundle':
+      cy.contains('Customize and Add to Cart').click()
+      break;
     case 'simple':
-    case 'bundle': // For now, we only have one option for each bundle option, so we don't have to do anything.
       // Do nothing
       break;
     default:
       throw 'Methinks thou hast forgotten something…'
   }
-  cy.contains('Add to Cart').click()
+  cy.get('#product-addtocart-button').click()
   cy.wait('@addToCartRequest') // Make sure that the cart addition has finished before continuing.
 })
 
@@ -51,14 +53,16 @@ When('I add a different {string} widget to my cart', function(type) {
       cy.get('#product_addtocart_form input[name="super_group[2]"]').clear().type('1')
       cy.get('#product_addtocart_form input[name="super_group[3]"]').clear().type('1')
       break;
+    case 'bundle':
+      cy.contains('Customize and Add to Cart').click()
+      break;
     case 'simple':
-    case 'bundle': // For now, we only have one option for each bundle option, so we don't have to do anything.
       // Do nothing
       break;
     default:
       throw 'Methinks thou hast forgotten something…'
   }
-  cy.contains('Add to Cart').click()
+  cy.get('#product-addtocart-button').click()
   cy.wait('@addToCartRequest') // Make sure that the cart addition has finished before continuing.
 })
 

--- a/devtools_m2/cypress/integration/CustomerCartInteractions/steps.js
+++ b/devtools_m2/cypress/integration/CustomerCartInteractions/steps.js
@@ -38,6 +38,30 @@ When('I add a {string} widget to my cart', function(type) {
   cy.wait('@addToCartRequest') // Make sure that the cart addition has finished before continuing.
 })
 
+// TODO: This is kind of ugly and duplicates the prior.
+When('I add a different {string} widget to my cart', function(type) {
+  cy.server()
+  cy.route('POST', 'checkout/cart/add/**').as('addToCartRequest')
+  cy.visit(`/widget-1.html`)
+  switch (type) {
+    case 'configurable':
+      cy.get('#product-options-wrapper select').select('L')
+      break;
+    case 'grouped':
+      cy.get('#product_addtocart_form input[name="super_group[2]"]').clear().type('1')
+      cy.get('#product_addtocart_form input[name="super_group[3]"]').clear().type('1')
+      break;
+    case 'simple':
+    case 'bundle': // For now, we only have one option for each bundle option, so we don't have to do anything.
+      // Do nothing
+      break;
+    default:
+      throw 'Methinks thou hast forgotten something…'
+  }
+  cy.contains('Add to Cart').click()
+  cy.wait('@addToCartRequest') // Make sure that the cart addition has finished before continuing.
+})
+
 Then('A simple cart event should be sent to Drip', function() {
   cy.log('Validating that the cart call has everything we need')
   cy.wrap(Mockclient.retrieveRecordedRequests({

--- a/devtools_m2/cypress/integration/CustomerCartInteractions/steps.js
+++ b/devtools_m2/cypress/integration/CustomerCartInteractions/steps.js
@@ -18,7 +18,7 @@ When('I create an account', function() {
 When('I add a {string} widget to my cart', function(type) {
   cy.server()
   cy.route('POST', 'checkout/cart/add/**').as('addToCartRequest')
-  cy.route('GET', '/customer/section/load/**').as('cartSectionLoading')
+  cy.route('GET', /\/customer\/section\/load\/\?sections=cart,customer,messages,compare\-products,product_data_storage,captcha&force_new_section_timestamp=false&_=\d+/).as('cartSectionLoading')
   cy.visit(`/widget-1.html`)
   switch (type) {
     case 'configurable':
@@ -29,12 +29,6 @@ When('I add a {string} widget to my cart', function(type) {
       cy.get('#product_addtocart_form input[name="super_group[3]"]').clear().type('1')
       break;
     case 'bundle':
-      // There are four of these guys, so we wait for all of them...
-      // The one we care about is http://main.magento.localhost:3006/customer/section/load/?sections=cart,customer,messages,compare-products,product_data_storage,captcha&force_new_section_timestamp=false&_=1571690556626
-      // but it seems like we can't match on query params.
-      cy.wait('@cartSectionLoading')
-      cy.wait('@cartSectionLoading')
-      cy.wait('@cartSectionLoading')
       cy.wait('@cartSectionLoading')
       cy.contains('Customize and Add to Cart').click()
       break;

--- a/devtools_m2/cypress/integration/CustomerCartInteractions/steps.js
+++ b/devtools_m2/cypress/integration/CustomerCartInteractions/steps.js
@@ -15,39 +15,410 @@ When('I create an account', function() {
   })
 })
 
-When('I add something to my cart', function() {
+When('I add a {string} widget to my cart', function(type) {
   cy.server()
   cy.route('POST', 'checkout/cart/add/**').as('addToCartRequest')
   cy.visit(`/widget-1.html`)
+  switch (type) {
+    case 'configurable':
+      cy.get('#product-options-wrapper select').select('XL')
+      break;
+    case 'grouped':
+      cy.get('#product_addtocart_form input[name="super_group[2]"]').clear().type('1')
+      cy.get('#product_addtocart_form input[name="super_group[3]"]').clear().type('1')
+      break;
+    case 'simple':
+    case 'bundle': // For now, we only have one option for each bundle option, so we don't have to do anything.
+      // Do nothing
+      break;
+    default:
+      throw 'Methinks thou hast forgotten something…'
+  }
   cy.contains('Add to Cart').click()
-  cy.wait('@addToCartRequest')
+  cy.wait('@addToCartRequest') // Make sure that the cart addition has finished before continuing.
 })
 
-Then('A cart event should be sent to Drip', function() {
-  cy.log('Validating subscriber mocks were called')
-  cy.then(function() {
-    return Mockclient.verify({
-      'path': '/v2/123456/subscribers'
-    }, 1, 1);
-  })
-  cy.log('Validating event mocks were called')
-  cy.then(function() {
-    return Mockclient.verify({
-      'path': '/v2/123456/events'
-    }, 2, 2);
-  })
-  cy.log('Validating cart mock was called')
-  cy.then(function() {
-    return Mockclient.verify({
-      'path': '/v3/123456/shopper_activity/cart'
-    }, 1, 1);
-  })
+Then('A simple cart event should be sent to Drip', function() {
   cy.log('Validating that the cart call has everything we need')
   cy.wrap(Mockclient.retrieveRecordedRequests({
     'path': '/v3/123456/shopper_activity/cart'
   })).then(function(recordedRequests) {
+    expect(recordedRequests).to.have.lengthOf(1)
     const body = JSON.parse(recordedRequests[0].body.string)
     expect(body.email).to.eq('testuser@example.com')
-    // expect(body.product_variant_id).to.eq('1234')
+    expect(body.action).to.eq('created')
+    expect(body.cart_id).to.eq('1')
+    expect(body.cart_url).to.startWith('http://main.magento.localhost:3006/drip/cart/index/q/1')
+    expect(body.currency).to.eq('USD')
+    expect(body.grand_total).to.eq(11.22)
+    expect(body.initial_status).to.eq('unsubscribed')
+    expect(body.items_count).to.eq(1)
+    expect(body.magento_source).to.eq('Storefront')
+    expect(body.provider).to.eq('magento')
+    expect(body.total_discounts).to.eq(0)
+    expect(body.version).to.match(/^Magento 2\.3\.2, Drip Extension \d+\.\d+\.\d+$/)
+    expect(body.items).to.have.lengthOf(1)
+
+    const item = body.items[0]
+    expect(item.product_id).to.eq('1')
+    expect(item.product_variant_id).to.eq('1')
+    expect(item.sku).to.eq('widg-1')
+    expect(item.categories).to.be.empty
+    expect(item.discounts).to.eq(0)
+    expect(item.image_url).to.eq('http://main.magento.localhost:3006/pub/media/catalog/product/')
+    expect(item.name).to.eq('Widget 1')
+    expect(item.price).to.eq(11.22)
+    expect(item.product_url).to.eq('http://main.magento.localhost:3006/widget-1.html')
+    expect(item.quantity).to.eq(1)
+    expect(item.total).to.eq(11.22)
+  })
+})
+
+Then('A configurable cart event should be sent to Drip', function() {
+  cy.log('Validating that the cart call has everything we need')
+  cy.wrap(Mockclient.retrieveRecordedRequests({
+    'path': '/v3/123456/shopper_activity/cart'
+  })).then(function(recordedRequests) {
+    expect(recordedRequests).to.have.lengthOf(1)
+    const body = JSON.parse(recordedRequests[0].body.string)
+    expect(body.email).to.eq('testuser@example.com')
+    expect(body.action).to.eq('created')
+    expect(body.cart_id).to.eq('1')
+    expect(body.cart_url).to.startWith('http://main.magento.localhost:3006/drip/cart/index/q/1')
+    expect(body.currency).to.eq('USD')
+    expect(body.grand_total).to.eq(11.22)
+    expect(body.initial_status).to.eq('unsubscribed')
+    expect(body.items_count).to.eq(1)
+    expect(body.magento_source).to.eq('Storefront')
+    expect(body.provider).to.eq('magento')
+    expect(body.total_discounts).to.eq(0)
+    expect(body.version).to.match(/^Magento 2\.3\.2, Drip Extension \d+\.\d+\.\d+$/)
+    expect(body.items).to.have.lengthOf(1)
+
+    const item = body.items[0]
+    expect(item.product_id).to.eq('3')
+    expect(item.product_variant_id).to.eq('1')
+    expect(item.sku).to.eq('widg-1-xl')
+    expect(item.categories).to.be.empty
+    expect(item.discounts).to.eq(0)
+    expect(item.image_url).to.eq('http://main.magento.localhost:3006/pub/media/catalog/product/')
+    expect(item.name).to.eq('Widget 1') // TODO: Figure out whether this is correct.
+    expect(item.price).to.eq(11.22)
+    expect(item.product_url).to.eq('http://main.magento.localhost:3006/widget-1.html')
+    expect(item.quantity).to.eq(1)
+    expect(item.total).to.eq(11.22)
+  })
+})
+
+Then('Configurable cart events should be sent to Drip', function() {
+  cy.log('Validating that the cart call has everything we need')
+  cy.wrap(Mockclient.retrieveRecordedRequests({
+    'path': '/v3/123456/shopper_activity/cart'
+  })).then(function(recordedRequests) {
+    expect(recordedRequests).to.have.lengthOf(2)
+    const body = JSON.parse(recordedRequests[recordedRequests.length - 1].body.string)
+    expect(body.email).to.eq('testuser@example.com')
+    expect(body.items).to.have.lengthOf(2)
+    const item1 = body.items[0]
+    expect(item1.product_id).to.eq('3')
+    expect(item1.product_variant_id).to.eq('1')
+    expect(item1.sku).to.eq('widg-1-xl')
+    const item2 = body.items[1]
+    expect(item2.product_id).to.eq('3')
+    expect(item2.product_variant_id).to.eq('2')
+    expect(item2.sku).to.eq('widg-1-l')
+  })
+})
+
+Then('A grouped cart event should be sent to Drip', function() {
+  cy.log('Validating that the cart call has everything we need')
+  cy.wrap(Mockclient.retrieveRecordedRequests({
+    'path': '/v3/123456/shopper_activity/cart'
+  })).then(function(recordedRequests) {
+    expect(recordedRequests).to.have.lengthOf(1)
+    const body = JSON.parse(recordedRequests[0].body.string)
+    expect(body.email).to.eq('testuser@example.com')
+    expect(body.action).to.eq('created')
+    expect(body.cart_id).to.eq('1')
+    expect(body.cart_url).to.startWith('http://main.magento.localhost:3006/drip/cart/index/q/1')
+    expect(body.currency).to.eq('USD')
+    expect(body.grand_total).to.eq(22.44)
+    expect(body.initial_status).to.eq('unsubscribed')
+    expect(body.items_count).to.eq(2)
+    expect(body.magento_source).to.eq('Storefront')
+    expect(body.provider).to.eq('magento')
+    expect(body.total_discounts).to.eq(0)
+    expect(body.version).to.match(/^Magento 2\.3\.2, Drip Extension \d+\.\d+\.\d+$/)
+    expect(body.items).to.have.lengthOf(2)
+
+    // These may be in any order, so we'll loop and assert based on SKU.
+    body.items.forEach(item => {
+      switch (item.sku) {
+        case 'widg-1-sub1':
+          expect(item.product_id).to.eq('2')
+          expect(item.product_variant_id).to.eq('2')
+          expect(item.name).to.eq('Widget 1 Sub 1')
+          expect(item.product_url).to.eq('http://main.magento.localhost:3006/widget-1-sub-1.html')
+          break;
+        case 'widg-1-sub2':
+          expect(item.product_id).to.eq('3')
+          expect(item.product_variant_id).to.eq('3')
+          expect(item.name).to.eq('Widget 1 Sub 2')
+          expect(item.product_url).to.eq('http://main.magento.localhost:3006/widget-1-sub-2.html')
+          break;
+        default:
+          expect.fail(`Unknown SKU: ${item.sku}`)
+          break;
+      }
+      expect(item.categories).to.be.empty
+      expect(item.discounts).to.eq(0)
+      expect(item.image_url).to.eq('http://main.magento.localhost:3006/pub/media/catalog/product/')
+      expect(item.price).to.eq(11.22)
+      expect(item.quantity).to.eq(1)
+      expect(item.total).to.eq(11.22)
+    });
+  })
+})
+
+Then('A bundle cart event should be sent to Drip', function() {
+  cy.log('Validating that the cart call has everything we need')
+  cy.wrap(Mockclient.retrieveRecordedRequests({
+    'path': '/v3/123456/shopper_activity/cart'
+  })).then(function(recordedRequests) {
+    expect(recordedRequests).to.have.lengthOf(1)
+    const body = JSON.parse(recordedRequests[0].body.string)
+    expect(body.email).to.eq('testuser@example.com')
+    expect(body.action).to.eq('created')
+    expect(body.cart_id).to.eq('1')
+    expect(body.cart_url).to.startWith('http://main.magento.localhost:3006/drip/cart/index/q/1')
+    expect(body.currency).to.eq('USD')
+    expect(body.grand_total).to.eq(22.44)
+    expect(body.initial_status).to.eq('unsubscribed')
+    expect(body.items_count).to.eq(1)
+    expect(body.magento_source).to.eq('Storefront')
+    expect(body.provider).to.eq('magento')
+    expect(body.total_discounts).to.eq(0)
+    expect(body.version).to.match(/^Magento 2\.3\.2, Drip Extension \d+\.\d+\.\d+$/)
+    expect(body.items).to.have.lengthOf(1)
+
+    // We don't send anything unique for the child products right now.
+    const item = body.items[0]
+    expect(item.product_id).to.eq('3')
+    expect(item.product_variant_id).to.eq('3')
+    expect(item.sku).to.eq('widg-1')
+    expect(item.categories).to.be.empty
+    expect(item.discounts).to.eq(0)
+    expect(item.image_url).to.eq('http://main.magento.localhost:3006/pub/media/catalog/product/')
+    expect(item.name).to.eq('Widget 1')
+    expect(item.price).to.eq(22.44)
+    expect(item.product_url).to.eq('http://main.magento.localhost:3006/widget-1.html')
+    expect(item.quantity).to.eq(1)
+    expect(item.total).to.eq(22.44)
+  })
+})
+
+When('I check out', function() {
+  cy.log('Resetting mocks')
+  cy.wrap(Mockclient.reset())
+
+  cy.route('POST', 'rest/default/V1/carts/**').as('cartBuilder')
+  cy.visit('/checkout/cart')
+  cy.wait('@cartBuilder')
+  cy.get('button[data-role="proceed-to-checkout"]').click()
+
+  cy.contains('Shipping Address', {timeout: 20000})
+  cy.get('input[name="street[0]"]').type('123 Main St.')
+  cy.get('input[name="city"]').type('Centerville')
+  cy.get('select[name="region_id"]').select('Minnesota')
+  cy.get('input[name="postcode"]').type('12345')
+  cy.get('input[name="telephone"]').type('999-999-9999')
+  cy.contains('Next').click()
+
+  // cy.route('GET', 'customer/section/load/?sections=cart,last-ordered-items,instant-purchase,messages&force_new_section_timestamp=true**').as('checkoutSections')
+  // // URL:          http://main.magento.localhost:3006/customer/section/load/?sections=cart,last-ordered-items,instant-purchase,messages&force_new_section_timestamp=true&_=1570808490447
+  // cy.wait('@checkoutSections')
+  cy.get('input[name="billing-address-same-as-shipping"]').check()
+
+  cy.contains('Place Order').click()
+  cy.contains('Thank you for your purchase!')
+})
+
+function basicOrderBodyAssertions(body) {
+  expect(body.currency).to.eq('USD')
+  expect(body.magento_source).to.eq('Storefront')
+  expect(body.occurred_at).to.match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/)
+  expect(body.order_id).to.eq('000000001')
+  expect(body.order_public_id).to.eq('000000001')
+  expect(body.provider).to.eq('magento')
+  expect(body.total_discounts).to.eq(0)
+  expect(body.total_taxes).to.eq(0)
+  expect(body.version).to.match(/^Magento 2\.3\.2, Drip Extension \d+\.\d+\.\d+$/)
+
+  expect(body.billing_address.address_1).to.eq('123 Main St.')
+  expect(body.billing_address.address_2).to.eq('')
+  expect(body.billing_address.city).to.eq('Centerville')
+  expect(body.billing_address.company).to.eq('')
+  expect(body.billing_address.country).to.eq('US')
+  expect(body.billing_address.first_name).to.eq('Test')
+  expect(body.billing_address.last_name).to.eq('User')
+  expect(body.billing_address.phone).to.eq('999-999-9999')
+  expect(body.billing_address.postal_code).to.eq('12345')
+  expect(body.billing_address.state).to.eq('Minnesota')
+
+  expect(body.shipping_address.address_1).to.eq('123 Main St.')
+  expect(body.shipping_address.address_2).to.eq('')
+  expect(body.shipping_address.city).to.eq('Centerville')
+  expect(body.shipping_address.company).to.eq('')
+  expect(body.shipping_address.country).to.eq('US')
+  expect(body.shipping_address.first_name).to.eq('Test')
+  expect(body.shipping_address.last_name).to.eq('User')
+  expect(body.shipping_address.phone).to.eq('999-999-9999')
+  expect(body.shipping_address.postal_code).to.eq('12345')
+  expect(body.shipping_address.state).to.eq('Minnesota')
+}
+
+Then('A simple order event should be sent to Drip', function() {
+  cy.log('Validating that the order call has everything we need')
+  cy.wrap(Mockclient.retrieveRecordedRequests({
+    'path': '/v3/123456/shopper_activity/order'
+  })).then(function(recordedRequests) {
+    expect(recordedRequests).to.have.lengthOf(1)
+    const body = JSON.parse(recordedRequests[0].body.string)
+    expect(body.action).to.eq('placed')
+    expect(body.email).to.eq('testuser@example.com')
+    expect(body.grand_total).to.eq(16.22)
+    expect(body.initial_status).to.eq('unsubscribed')
+    expect(body.items_count).to.eq(1)
+    expect(body.total_shipping).to.eq(5)
+    expect(body.items).to.have.lengthOf(1)
+
+    basicOrderBodyAssertions(body)
+
+    const item = body.items[0]
+    expect(item.categories).to.be.empty
+    expect(item.discounts).to.eq(0)
+    expect(item.image_url).to.eq('http://main.magento.localhost:3006/pub/media/catalog/product/')
+    expect(item.name).to.eq('Widget 1')
+    expect(item.price).to.eq(11.22)
+    expect(item.product_id).to.eq('1')
+    expect(item.product_variant_id).to.eq('1')
+    expect(item.product_url).to.eq('http://main.magento.localhost:3006/widget-1.html')
+    expect(item.quantity).to.eq(1)
+    expect(item.sku).to.eq('widg-1')
+    expect(item.taxes).to.eq(0)
+    expect(item.total).to.eq(11.22)
+  })
+})
+
+Then('A configurable order event should be sent to Drip', function() {
+  cy.log('Validating that the order call has everything we need')
+  cy.wrap(Mockclient.retrieveRecordedRequests({
+    'path': '/v3/123456/shopper_activity/order'
+  })).then(function(recordedRequests) {
+    expect(recordedRequests).to.have.lengthOf(1)
+    const body = JSON.parse(recordedRequests[0].body.string)
+    expect(body.action).to.eq('placed')
+    expect(body.email).to.eq('testuser@example.com')
+    expect(body.grand_total).to.eq(16.22)
+    expect(body.initial_status).to.eq('unsubscribed')
+    expect(body.items_count).to.eq(1)
+    expect(body.total_shipping).to.eq(5)
+    expect(body.items).to.have.lengthOf(1)
+
+    basicOrderBodyAssertions(body)
+
+    const item = body.items[0]
+    expect(item.categories).to.be.empty
+    expect(item.discounts).to.eq(0)
+    expect(item.image_url).to.eq('http://main.magento.localhost:3006/pub/media/catalog/product/')
+    expect(item.name).to.eq('Widget 1')
+    expect(item.price).to.eq(11.22)
+    expect(item.product_id).to.eq('3')
+    expect(item.product_variant_id).to.eq('1')
+    expect(item.product_url).to.eq('http://main.magento.localhost:3006/widget-1.html')
+    expect(item.quantity).to.eq(1)
+    expect(item.sku).to.eq('widg-1-xl')
+    expect(item.taxes).to.eq(0)
+    expect(item.total).to.eq(11.22)
+  })
+})
+
+Then('A grouped order event should be sent to Drip', function() {
+  cy.log('Validating that the order call has everything we need')
+  cy.wrap(Mockclient.retrieveRecordedRequests({
+    'path': '/v3/123456/shopper_activity/order'
+  })).then(function(recordedRequests) {
+    expect(recordedRequests).to.have.lengthOf(1)
+    const body = JSON.parse(recordedRequests[0].body.string)
+    expect(body.action).to.eq('placed')
+    expect(body.email).to.eq('testuser@example.com')
+    expect(body.grand_total).to.eq(32.44)
+    expect(body.initial_status).to.eq('unsubscribed')
+    expect(body.items_count).to.eq(2)
+    expect(body.total_shipping).to.eq(10)
+    expect(body.items).to.have.lengthOf(2)
+
+    basicOrderBodyAssertions(body)
+
+    const item1 = body.items[0]
+    expect(item1.categories).to.be.empty
+    expect(item1.discounts).to.eq(0)
+    expect(item1.image_url).to.eq('http://main.magento.localhost:3006/pub/media/catalog/product/')
+    expect(item1.name).to.eq('Widget 1 Sub 1')
+    expect(item1.price).to.eq(11.22)
+    expect(item1.product_id).to.eq('2')
+    expect(item1.product_variant_id).to.eq('2')
+    expect(item1.product_url).to.eq('http://main.magento.localhost:3006/widget-1-sub-1.html')
+    expect(item1.quantity).to.eq(1)
+    expect(item1.sku).to.eq('widg-1-sub1')
+    expect(item1.taxes).to.eq(0)
+    expect(item1.total).to.eq(11.22)
+
+    const item2 = body.items[1]
+    expect(item2.categories).to.be.empty
+    expect(item2.discounts).to.eq(0)
+    expect(item2.image_url).to.eq('http://main.magento.localhost:3006/pub/media/catalog/product/')
+    expect(item2.name).to.eq('Widget 1 Sub 2')
+    expect(item2.price).to.eq(11.22)
+    expect(item2.product_id).to.eq('3')
+    expect(item2.product_variant_id).to.eq('3')
+    expect(item2.product_url).to.eq('http://main.magento.localhost:3006/widget-1-sub-2.html')
+    expect(item2.quantity).to.eq(1)
+    expect(item2.sku).to.eq('widg-1-sub2')
+    expect(item2.taxes).to.eq(0)
+    expect(item2.total).to.eq(11.22)
+  })
+})
+
+Then('A bundle order event should be sent to Drip', function() {
+  cy.log('Validating that the order call has everything we need')
+  cy.wrap(Mockclient.retrieveRecordedRequests({
+    'path': '/v3/123456/shopper_activity/order'
+  })).then(function(recordedRequests) {
+    expect(recordedRequests).to.have.lengthOf(1)
+    const body = JSON.parse(recordedRequests[0].body.string)
+    expect(body.action).to.eq('placed')
+    expect(body.email).to.eq('testuser@example.com')
+    expect(body.grand_total).to.eq(27.44)
+    expect(body.initial_status).to.eq('unsubscribed')
+    expect(body.items_count).to.eq(1)
+    expect(body.total_shipping).to.eq(5)
+    expect(body.items).to.have.lengthOf(1)
+
+    basicOrderBodyAssertions(body)
+
+    const item = body.items[0]
+    expect(item.categories).to.be.empty
+    expect(item.discounts).to.eq(0)
+    expect(item.image_url).to.eq('http://main.magento.localhost:3006/pub/media/catalog/product/')
+    expect(item.name).to.eq('Widget 1')
+    expect(item.price).to.eq(22.44)
+    expect(item.product_id).to.eq('3')
+    expect(item.product_variant_id).to.eq('3')
+    expect(item.product_url).to.eq('http://main.magento.localhost:3006/widget-1.html')
+    expect(item.quantity).to.eq(1)
+    expect(item.sku).to.eq('widg-1')
+    expect(item.taxes).to.eq(0)
+    expect(item.total).to.eq(22.44)
   })
 })

--- a/devtools_m2/cypress/integration/CustomerCartInteractions/steps.js
+++ b/devtools_m2/cypress/integration/CustomerCartInteractions/steps.js
@@ -251,7 +251,7 @@ When('I check out', function() {
 
   cy.route('POST', 'rest/default/V1/carts/**').as('cartBuilder')
   cy.visit('/checkout/cart')
-  cy.wait('@cartBuilder')
+  cy.wait('@cartBuilder', { requestTimeout: 10000 })
   cy.get('button[data-role="proceed-to-checkout"]').click()
 
   cy.contains('Shipping Address', {timeout: 20000})

--- a/devtools_m2/cypress/integration/CustomerSubscriptionInteractions.feature
+++ b/devtools_m2/cypress/integration/CustomerSubscriptionInteractions.feature
@@ -1,0 +1,22 @@
+Feature: Customer Subscription Interactions
+
+  I want to send login and subscription change events
+
+  Scenario: A customer creates a subscribed account and then unsubscribes
+    Given I am logged into the admin interface
+      And I have configured Drip to be enabled for 'main'
+    When I open the 'main' homepage
+      And I create a 'subscribed' account
+    Then A new 'subscribed' subscriber event should be sent to Drip
+    When I 'unsubscribe' from the general newsletter
+    Then A 'unsubscribed' event should be sent to Drip
+
+  @focus
+  Scenario: A customer creates an unsubscribed account and then subscribes
+    Given I am logged into the admin interface
+      And I have configured Drip to be enabled for 'main'
+    When I open the 'main' homepage
+      And I create a 'unsubscribed' account
+    Then A new 'unsubscribed' subscriber event should be sent to Drip
+    When I 'subscribe' from the general newsletter
+    Then A 'subscribed' event should be sent to Drip

--- a/devtools_m2/cypress/integration/CustomerSubscriptionInteractions/steps.js
+++ b/devtools_m2/cypress/integration/CustomerSubscriptionInteractions/steps.js
@@ -1,0 +1,139 @@
+import { Given, When, Then } from "cypress-cucumber-preprocessor/steps"
+import { mockServerClient } from "mockserver-client"
+
+const Mockclient = mockServerClient("localhost", 1080);
+
+When('I create a {string} account', function(state) {
+  cy.contains('Create an Account').click()
+  cy.get('#form-validate').within(function() {
+    cy.get('input[name="firstname"]').type('Test')
+    cy.get('input[name="lastname"]').type('User')
+    cy.get('input[name="email"]').type('testuser@example.com')
+    cy.get('input[name="password"]').type('blahblah123!!!')
+    cy.get('input[name="password_confirmation"]').type('blahblah123!!!')
+    if (state === 'subscribed') {
+      cy.get('input[name="is_subscribed"]').check()
+    }
+    cy.contains('Create an Account').click()
+  })
+})
+
+Then('A new {string} subscriber event should be sent to Drip', function(state) {
+  cy.log('Validating that the subscriber call has everything we need')
+
+  cy.wrap(Mockclient.retrieveRecordedRequests()).then(function(req){
+    console.log(req)
+  })
+
+  cy.wrap(Mockclient.retrieveRecordedRequests({
+    'path': '/v2/123456/subscribers'
+  })).then(function(recordedRequests) {
+    console.log(recordedRequests)
+    expect(recordedRequests).to.have.lengthOf(1)
+    const body = JSON.parse(recordedRequests[0].body.string)
+    expect(body.subscribers).to.have.lengthOf(1)
+
+    const sub = body.subscribers[0]
+    expect(sub.email).to.eq('testuser@example.com')
+    expect(sub.new_email).to.eq('')
+
+    if (state === 'subscribed') {
+      expect(sub.initial_status).to.eq('active')
+      expect(sub.custom_fields.accepts_marketing).to.eq('yes')
+      expect(sub.status).to.eq('active')
+    } else {
+      expect(sub.initial_status).to.eq('unsubscribed')
+      expect(sub.custom_fields.accepts_marketing).to.eq('no')
+      expect(sub.status).to.be.undefined
+    }
+
+    expect(sub.custom_fields.birthday).to.be.null
+    expect(sub.custom_fields.first_name).to.eq('Test')
+    expect(sub.custom_fields.gender).to.eq('')
+    expect(sub.custom_fields.last_name).to.eq('User')
+    expect(sub.custom_fields.magento_customer_group).to.eq('General')
+    expect(sub.custom_fields.magento_store).to.eq(1)
+  })
+
+  cy.log('Validating that the event calls have everything we need')
+  cy.wrap(Mockclient.retrieveRecordedRequests({
+    'path': '/v2/123456/events'
+  })).then(function(recordedRequests) {
+    expect(recordedRequests).to.have.lengthOf(2)
+    const custCreatedBody = JSON.parse(recordedRequests[0].body.string)
+    expect(custCreatedBody.events).to.have.lengthOf(1)
+    expect(custCreatedBody.events[0].action).to.eq('Customer created')
+    expect(custCreatedBody.events[0].email).to.eq('testuser@example.com')
+    expect(custCreatedBody.events[0].properties.magento_source).to.eq('Storefront')
+    expect(custCreatedBody.events[0].properties.source).to.eq('magento')
+    expect(custCreatedBody.events[0].properties.version).to.match(/^Magento 2\.3\.2, Drip Extension \d+\.\d+\.\d+$/)
+
+    const custLoggedInBody = JSON.parse(recordedRequests[1].body.string)
+    expect(custLoggedInBody.events).to.have.lengthOf(1)
+    expect(custLoggedInBody.events[0].action).to.eq('Customer logged in')
+    expect(custLoggedInBody.events[0].email).to.eq('testuser@example.com')
+    expect(custLoggedInBody.events[0].properties.magento_source).to.eq('Storefront')
+    expect(custLoggedInBody.events[0].properties.source).to.eq('magento')
+    expect(custLoggedInBody.events[0].properties.version).to.match(/^Magento 2\.3\.2, Drip Extension \d+\.\d+\.\d+$/)
+  })
+})
+
+When('I {string} from the general newsletter', function(state) {
+  cy.log('Resetting mocks')
+  cy.wrap(Mockclient.reset())
+
+  cy.visit('/newsletter/manage/')
+
+  if (state === 'unsubscribe') {
+    cy.get('input[name="is_subscribed"]').uncheck()
+  } else {
+    cy.get('input[name="is_subscribed"]').check()
+  }
+  cy.contains('Save').click()
+})
+
+Then('A {string} event should be sent to Drip', function(state) {
+  cy.log('Validating that the subscriber call has everything we need')
+  cy.wrap(Mockclient.retrieveRecordedRequests({
+    'path': '/v2/123456/subscribers'
+  })).then(function(recordedRequests) {
+    expect(recordedRequests).to.have.lengthOf(1)
+    const body = JSON.parse(recordedRequests[0].body.string)
+    expect(body.subscribers).to.have.lengthOf(1)
+
+    const sub = body.subscribers[0]
+    expect(sub.email).to.eq('testuser@example.com')
+    expect(sub.new_email).to.eq('')
+
+    if (state === 'subscribed') {
+      expect(sub.initial_status).to.eq('active')
+      expect(sub.custom_fields.accepts_marketing).to.eq('yes')
+      expect(sub.status).to.eq('active')
+    } else {
+      expect(sub.initial_status).to.eq('unsubscribed')
+      expect(sub.custom_fields.accepts_marketing).to.eq('no')
+      expect(sub.status).to.eq('unsubscribed')
+    }
+
+    expect(sub.custom_fields.birthday).to.be.null
+    expect(sub.custom_fields.first_name).to.eq('Test')
+    expect(sub.custom_fields.gender).to.eq('')
+    expect(sub.custom_fields.last_name).to.eq('User')
+    expect(sub.custom_fields.magento_customer_group).to.eq('General')
+    expect(sub.custom_fields.magento_store).to.eq(1)
+  })
+
+  cy.log('Validating that the event calls have everything we need')
+  cy.wrap(Mockclient.retrieveRecordedRequests({
+    'path': '/v2/123456/events'
+  })).then(function(recordedRequests) {
+    expect(recordedRequests).to.have.lengthOf(1)
+    const custCreatedBody = JSON.parse(recordedRequests[0].body.string)
+    expect(custCreatedBody.events).to.have.lengthOf(1)
+    expect(custCreatedBody.events[0].action).to.eq('Customer updated')
+    expect(custCreatedBody.events[0].email).to.eq('testuser@example.com')
+    expect(custCreatedBody.events[0].properties.magento_source).to.eq('Storefront')
+    expect(custCreatedBody.events[0].properties.source).to.eq('magento')
+    expect(custCreatedBody.events[0].properties.version).to.match(/^Magento 2\.3\.2, Drip Extension \d+\.\d+\.\d+$/)
+  })
+})

--- a/devtools_m2/cypress/integration/common/admin.js
+++ b/devtools_m2/cypress/integration/common/admin.js
@@ -10,19 +10,27 @@ Given('I am logged into the admin interface', function() {
 Given('I have set up a multi-store configuration', function() {
   cy.contains('All Stores').click({ force: true })
 
+  // globals.js defines window.setLocation, which is loaded async. We need to wait for this to be loaded.
+  cy.window().its('setLocation')
+
   cy.contains('Create Website').click()
+  cy.window().its('setLocation')
   cy.get('input[name="website[name]"]').type('site1_website')
   cy.get('input[name="website[code]"]').type('site1_website')
   cy.contains('Save Web Site').click()
 
+  cy.window().its('setLocation')
   cy.get('button#add_group').click()
+  cy.window().its('setLocation')
   cy.get('select[name="group[website_id]"]').select('site1_website')
   cy.get('input[name="group[name]"]').type('site1_store')
   cy.get('input[name="group[code]"]').type('site1_store')
   cy.get('select[name="group[root_category_id]"]').select('Default Category')
   cy.contains('Save Store').click()
 
+  cy.window().its('setLocation')
   cy.contains('Create Store View').click()
+  cy.window().its('setLocation')
   cy.get('select[name="store[group_id]"]').select('site1_store')
   cy.get('input[name="store[name]"]').type('site1_store_view')
   cy.get('input[name="store[code]"]').type('site1_store_view')

--- a/devtools_m2/cypress/integration/common/admin.js
+++ b/devtools_m2/cypress/integration/common/admin.js
@@ -52,33 +52,17 @@ Given('I have set up a multi-store configuration', function() {
   cy.contains('Save Config').click()
 })
 
-Given('I have configured Drip to be enabled for site1', function() {
-  // cy.get('[data-ui-id="menu-magento-backend-stores-settings"]').within(function() {
-  //   cy.contains('Configuration').click({ force: true })
-  // })
-  cy.contains('Drip Connect').click({ force: true })
-  // cy.get('select#store_switcher').select('site1_website')
-  cy.contains('Module Settings').click()
-  cy.contains('API Settings').click()
-  cy.get('input[name="groups[module_settings][fields][is_enabled][inherit]"]').uncheck()
-  cy.get('select[name="groups[module_settings][fields][is_enabled][value]"]').select('Yes')
-  cy.get('input[name="groups[api_settings][fields][account_id][inherit]"]').uncheck()
-  cy.get('input[name="groups[api_settings][fields][account_id][value]"]').type('123456')
-  cy.get('input[name="groups[api_settings][fields][api_key][inherit]"]').uncheck()
-  cy.get('input[name="groups[api_settings][fields][api_key][value]"]').type('abc123')
-  cy.get('input[name="groups[api_settings][fields][url][inherit]"]').uncheck()
-  cy.get('input[name="groups[api_settings][fields][url][value]"]').clear().type('http://mock:1080/v2/')
-  cy.contains('Save Config').click()
-})
-
-Given('I have configured Drip to be enabled for main', function() {
-  // cy.get('[data-ui-id="menu-magento-backend-stores-settings"]').within(function() {
-  //   cy.contains('Configuration').click({ force: true })
-  // })
-  cy.contains('Drip Connect').click({ force: true })
+Given('I have configured Drip to be enabled for {string}', function(site) {
+  cy.get('li[data-ui-id="menu-magento-config-system-config"] a').click({force: true})
+  cy.contains('Drip Connect', {timeout: 20000}).click({ force: true })
+  let websiteKey
+  if (site == 'main') {
+    websiteKey = 'Main Website'
+  } else {
+    websiteKey = `${site}_website`
+  }
   cy.get('div.store-switcher').within(function() {
-    // cy.get('button#store-change-button').click({force: true})
-    cy.contains('Main Website').trigger('click', {force: true})
+    cy.contains(websiteKey).trigger('click', {force: true})
   })
   cy.contains('OK').click()
   cy.contains('Module Settings').click()

--- a/devtools_m2/cypress/integration/common/admin.js
+++ b/devtools_m2/cypress/integration/common/admin.js
@@ -89,3 +89,102 @@ Given('I have configured a widget', function() {
   cy.get('input[name="product[quantity_and_stock_status][qty]"]').type('120')
   cy.contains('Save').click()
 })
+
+// Simple Product
+Given('I have configured a simple widget', function() {
+  cy.createProduct({
+    "sku": "widg-1",
+    "name": "Widget 1",
+    "description": "This is really a widget. There are many like it, but this one is mine.",
+    "shortDescription": "This is really a widget.",
+  })
+})
+
+// Configurable Product
+Given('I have configured a configurable widget', function() {
+  cy.createProduct({
+    "sku": "widg-1",
+    "name": "Widget 1",
+    "description": "This is really a widget. There are many like it, but this one is mine.",
+    "shortDescription": "This is really a widget.",
+    "typeId": "configurable",
+    "attributes": {
+      "widget_size": {
+        "XL": {
+          "sku": "widg-1-xl",
+          "name": "Widget 1 XL",
+          "description": "This is really an XL widget. There are many like it, but this one is mine.",
+          "shortDescription": "This is really an XL widget.",
+        },
+        "L": {
+          "sku": "widg-1-l",
+          "name": "Widget 1 L",
+          "description": "This is really an L widget. There are many like it, but this one is mine.",
+          "shortDescription": "This is really an L widget.",
+        }
+      }
+    }
+  })
+})
+
+// Grouped Product
+Given('I have configured a grouped widget', function() {
+  cy.createProduct({
+    "sku": "widg-1",
+    "name": "Widget 1",
+    "description": "This is really a widget. There are many like it, but this one is mine.",
+    "shortDescription": "This is really a widget.",
+    "typeId": "grouped",
+    "associated": [
+      {
+        "sku": "widg-1-sub1",
+        "name": "Widget 1 Sub 1",
+        "description": "This is really a sub1 widget. There are many like it, but this one is mine.",
+        "shortDescription": "This is really a sub1 widget.",
+      },
+      {
+        "sku": "widg-1-sub2",
+        "name": "Widget 1 Sub 2",
+        "description": "This is really a sub2 widget. There are many like it, but this one is mine.",
+        "shortDescription": "This is really a sub2 widget.",
+      }
+    ]
+  })
+})
+
+// Bundle Product
+Given('I have configured a bundle widget', function() {
+  // skuType of 1 is a fixed sku rather than generating a composite SKU.
+  cy.createProduct({
+    "sku": "widg-1",
+    "skuType": 1,
+    "name": "Widget 1",
+    "description": "This is really a widget. There are many like it, but this one is mine.",
+    "shortDescription": "This is really a widget.",
+    "typeId": "bundle",
+    "bundle_options": [
+      {
+        "title": "item01",
+        "product_options": [
+          {
+            "sku": "widg-1-sub1",
+            "name": "Widget 1 Sub 1",
+            "description": "This is really a sub1 widget. There are many like it, but this one is mine.",
+            "shortDescription": "This is really a sub1 widget.",
+          }
+        ]
+      },
+      {
+        "title": "item02",
+        "product_options": [
+          {
+            "sku": "widg-1-sub2",
+            "name": "Widget 1 Sub 2",
+            "description": "This is really a sub2 widget. There are many like it, but this one is mine.",
+            "shortDescription": "This is really a sub2 widget.",
+          }
+        ]
+      }
+    ]
+  })
+})

--- a/devtools_m2/cypress/integration/common/admin.js
+++ b/devtools_m2/cypress/integration/common/admin.js
@@ -165,6 +165,7 @@ Given('I have configured a bundle widget', function() {
     "bundle_options": [
       {
         "title": "item01",
+        "default_title": "item01",
         "product_options": [
           {
             "sku": "widg-1-sub1",
@@ -176,6 +177,7 @@ Given('I have configured a bundle widget', function() {
       },
       {
         "title": "item02",
+        "default_title": "item02",
         "product_options": [
           {
             "sku": "widg-1-sub2",

--- a/devtools_m2/cypress/integration/common/multi_store.js
+++ b/devtools_m2/cypress/integration/common/multi_store.js
@@ -1,9 +1,5 @@
 import { Given, When, Then } from "cypress-cucumber-preprocessor/steps"
 
-When('I open the site1 homepage', function() {
-  cy.visit(`http://site1.magento.localhost:3006/`)
-})
-
-When('I open the main homepage', function() {
-  cy.visit(`http://main.magento.localhost:3006/`)
+When('I open the {string} homepage', function(site) {
+  cy.visit(`http://${site}.magento.localhost:3006/`)
 })

--- a/devtools_m2/cypress/plugins/index.js
+++ b/devtools_m2/cypress/plugins/index.js
@@ -23,7 +23,7 @@ module.exports = (on, config) => {
   config.defaultCommandTimeout = 10000 // Default: 4000
   // config.execTimeout = 60000 // Default: 60000
   // config.taskTimeout = 60000 // Default: 60000
-  // config.pageLoadTimeout = 60000 // Default: 60000
+  config.pageLoadTimeout = 100000 // Default: 60000
   config.requestTimeout = 10000 // Default: 5000
   config.responseTimeout = 10000 // Default: 3000
 }

--- a/devtools_m2/cypress/plugins/index.js
+++ b/devtools_m2/cypress/plugins/index.js
@@ -18,12 +18,4 @@ module.exports = (on, config) => {
   // `config` is the resolved Cypress config
 
   on('file:preprocessor', cucumber())
-
-  // Magento is slow. We're going to generally bump up timeouts
-  config.defaultCommandTimeout = 10000 // Default: 4000
-  // config.execTimeout = 60000 // Default: 60000
-  // config.taskTimeout = 60000 // Default: 60000
-  config.pageLoadTimeout = 100000 // Default: 60000
-  config.requestTimeout = 10000 // Default: 5000
-  config.responseTimeout = 10000 // Default: 3000
 }

--- a/devtools_m2/cypress/plugins/index.js
+++ b/devtools_m2/cypress/plugins/index.js
@@ -18,4 +18,12 @@ module.exports = (on, config) => {
   // `config` is the resolved Cypress config
 
   on('file:preprocessor', cucumber())
+
+  // Magento is slow. We're going to generally bump up timeouts
+  config.defaultCommandTimeout = 10000 // Default: 4000
+  // config.execTimeout = 60000 // Default: 60000
+  // config.taskTimeout = 60000 // Default: 60000
+  // config.pageLoadTimeout = 60000 // Default: 60000
+  config.requestTimeout = 10000 // Default: 5000
+  config.responseTimeout = 10000 // Default: 3000
 }

--- a/devtools_m2/cypress/support/commands.js
+++ b/devtools_m2/cypress/support/commands.js
@@ -23,3 +23,10 @@
 //
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+
+afterEach(function() {
+  // https://github.com/cypress-io/cypress/issues/216
+  // https://github.com/cypress-io/cypress/issues/686
+  cy.log('Reset web interface to avoid bleed-over')
+  cy.visit('/lib/web/blank.html', { failOnStatusCode: false })
+})

--- a/devtools_m2/cypress/support/index.js
+++ b/devtools_m2/cypress/support/index.js
@@ -13,6 +13,8 @@
 // https://on.cypress.io/configuration
 // ***********************************************************
 
+import chaiString from 'chai-string';
+
 // Import commands.js using ES2015 syntax:
 import './commands'
 import './docker_helpers'

--- a/devtools_m2/cypress/support/index.js
+++ b/devtools_m2/cypress/support/index.js
@@ -19,6 +19,9 @@ import chaiString from 'chai-string';
 import './commands'
 import './docker_helpers'
 import './mocking_helpers'
+import './product_management'
+
+chai.use(chaiString)
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/devtools_m2/cypress/support/product_management.js
+++ b/devtools_m2/cypress/support/product_management.js
@@ -1,0 +1,15 @@
+Cypress.Commands.add("createProduct", (desc) => {
+  // You must provide at least the following:
+  // "sku"
+  // "name"
+  // "description"
+  // "shortDescription"
+
+  cy.log('Creating magento product')
+  const str = JSON.stringify(desc)
+  cy.exec(`echo '${str}' | ./docker_compose.sh exec -u www-data -T web bin/magento drip_testutils:createproduct`, {
+    env: {
+      DRIP_COMPOSE_ENV: 'test'
+    }
+  })
+})

--- a/devtools_m2/docker-compose.test.yml
+++ b/devtools_m2/docker-compose.test.yml
@@ -3,6 +3,10 @@ services:
   web:
     links:
     - 'mock'
+    volumes:
+      - type: bind
+        source: './php_utils'
+        target: /var/www/html/magento/app/code/Drip/TestUtils
   db:
     tmpfs: /var/lib/mysql
   mock:

--- a/devtools_m2/package-lock.json
+++ b/devtools_m2/package-lock.json
@@ -1544,6 +1544,11 @@
         "type-detect": "^4.0.5"
       }
     },
+    "chai-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/chai-string/-/chai-string-1.5.0.tgz",
+      "integrity": "sha512-sydDC3S3pNAQMYwJrs6dQX0oBQ6KfIPuOZ78n7rocW0eJJlsHPh2t3kwW7xfwYA/1Bf6/arGtSUo16rxR2JFlw=="
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",

--- a/devtools_m2/package.json
+++ b/devtools_m2/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
+    "chai-string": "^1.5.0",
     "cypress": "^3.4.1",
     "cypress-cucumber-preprocessor": "^1.13.0",
     "mockserver-client": "^5.6.1"

--- a/devtools_m2/php_utils/Console/Command/CreateProductCommand.php
+++ b/devtools_m2/php_utils/Console/Command/CreateProductCommand.php
@@ -1,0 +1,269 @@
+<?php
+
+namespace Drip\TestUtils\Console\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CreateProductCommand extends Command
+{
+    /** @var \Magento\Catalog\Model\ProductFactory */
+    protected $catalogProductFactory;
+
+    /** @var \Magento\Framework\App\State **/
+    private $state;
+
+    public function __construct(
+        \Magento\Catalog\Model\ProductFactory $catalogProductFactory,
+        \Magento\Framework\App\State $state
+    ) {
+        parent::__construct();
+
+        $this->catalogProductFactory = $catalogProductFactory;
+        $this->state = $state;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName('drip_testutils:createproduct')->setDescription('Create product using JSON from stdin');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        // Some bookkeeping
+        $this->state->setAreaCode(\Magento\Framework\App\Area::AREA_FRONTEND);
+
+        $stdin = fopen('php://stdin', 'r');
+        $data = stream_get_contents($stdin);
+        $json = json_decode($data, true);
+
+        if ($json === null) {
+            throw new \Exception('Null JSON parse');
+        }
+
+        $type = array_key_exists('typeId', $json) ? $json['typeId'] : '';
+        switch ($type) {
+            case 'simple':
+            case '':
+            case null:
+                $this->buildSimpleProduct($json)->save();
+                break;
+            case 'configurable':
+                $this->buildConfigurableProduct($json);
+                break;
+            case 'grouped':
+                $this->buildGroupedProduct($json);
+                break;
+            case 'bundle':
+                $this->buildBundleProduct($json);
+                break;
+            default:
+                throw new \Exception("Unsupported type: ${type}");
+        }
+    }
+
+    protected function buildSimpleProduct($data)
+    {
+        $product = $this->catalogProductFactory->create();
+
+        $defaultAttrSetId = $product->getDefaultAttributeSetId();
+
+        $defaults = array(
+            "storeId" => 1,
+            "websiteIds" => [1],
+            "typeId" => "simple",
+            "weight" => 4.0000,
+            "status" => 1, //product status (1 - enabled, 2 - disabled)
+            "taxClassId" => 0, //tax class (0 - none, 1 - default, 2 - taxable, 4 - shipping)
+            "price" => 11.22,
+            "cost" => 22.33,
+            "attributeSetId" => $defaultAttrSetId,
+            "createdAt" => strtotime('now'),
+            "updatedAt" => strtotime('now'),
+            "stockData" => array(
+                "use_config_manage_stock" => 0,
+                "manage_stock" => 1,
+                "is_in_stock" => 1,
+                "qty" => 999
+            ),
+        );
+        $fullData = array_replace_recursive($defaults, $data);
+
+        // This assumes that you properly name all of the attributes. But we control both ends, so it should be fine.
+        foreach ($fullData as $key => $value) {
+            $methodName = "set".ucfirst($key);
+            $product->$methodName($value);
+        }
+
+        $product->setVisibility(\Magento\Catalog\Model\Product\Visibility::VISIBILITY_BOTH); //catalog and search visibility
+
+        return $product;
+    }
+
+    protected function buildAttribute($title, $options)
+    {
+        $installer = new Mage_Eav_Model_Entity_Setup('core_setup');
+        $installer->startSetup();
+        $installer->addAttribute('catalog_product', $title, array(
+            'group' => 'General',
+            'label' => $title,
+            'input' => 'select',
+            'type' => 'varchar',
+            'required' => 0,
+            'visible_on_front' => false,
+            'filterable' => 0,
+            'filterable_in_search' => 0,
+            'searchable' => 0,
+            'used_in_product_listing' => true,
+            'visible_in_advanced_search' => false,
+            'comparable' => 0,
+            'user_defined' => 1,
+            'is_configurable' => 0,
+            'global' => Mage_Catalog_Model_Resource_Eav_Attribute::SCOPE_GLOBAL,
+            'option' => array('values' => $options),
+            'note' => '',
+        ));
+
+        $installer->endSetup();
+
+        // Obtain and return the attribute.
+        return Mage::getModel('eav/config')->getAttribute('catalog_product', $title);
+    }
+
+    protected function buildConfigurableProduct($data)
+    {
+        $attributes = $data['attributes'];
+        unset($data['attributes']);
+
+        $configProduct = $this->buildSimpleProduct($data);
+        $configProduct->setStockData(array(
+            'use_config_manage_stock' => 0, //'Use config settings' checkbox
+            'manage_stock' => 1, //manage stock
+            'is_in_stock' => 1, //Stock Availability
+        ));
+
+        $attributeIds = array();
+        $configurableProductsData = array();
+
+        foreach ($attributes as $attrName => $attrValues) {
+            $attribute = $this->buildAttribute($attrName, array_keys($attrValues));
+            $attributeIds[] = $attribute->getId();
+
+            foreach ($attrValues as $option => $simpleProductData) {
+                $simpleProduct = $this->buildSimpleProduct($simpleProductData);
+                $optionId = $attribute->setStoreId(0)->getSource()->getOptionId($option);
+                $simpleProduct->setData($attrName, $optionId);
+                $simpleProduct->save();
+
+                $configurableProductsData[$simpleProduct->getId()][] = array(
+                    'label' => $option,
+                    'attribute_id' => $attribute->getId(),
+                    'value_index' => $optionId,
+                    'is_percent' => '0', //fixed/percent price for this option
+                    'pricing_value' => $simpleProduct->getPrice()
+                );
+            }
+        }
+
+        // Set attribute data
+        $configProduct->getTypeInstance()->setUsedProductAttributeIds($attributeIds);
+        $configurableAttributesData = $configProduct->getTypeInstance()->getConfigurableAttributesAsArray();
+        $configProduct->setCanSaveConfigurableAttributes(true);
+        $configProduct->setConfigurableAttributesData($configurableAttributesData);
+        $configProduct->setConfigurableProductsData($configurableProductsData);
+
+        $configProduct->save();
+    }
+
+    protected function buildGroupedProduct($data)
+    {
+        $associated = $data['associated'];
+        unset($data['associated']);
+
+        $groupedProduct = $this->buildSimpleProduct($data);
+        $groupedProduct->setStockData(array(
+            'use_config_manage_stock' => 0, //'Use config settings' checkbox
+            'manage_stock' => 1, //manage stock
+            'is_in_stock' => 1, //Stock Availability
+        ));
+        $groupedProduct->save();
+
+        $products_links = Mage::getModel('catalog/product_link_api');
+
+        foreach ($associated as $simpleProductData) {
+            $simpleProduct = $this->buildSimpleProduct($simpleProductData);
+            $simpleProduct->save();
+            $products_links->assign("grouped", $groupedProduct->getId(), $simpleProduct->getId());
+        }
+    }
+
+    protected function buildBundleProduct($data)
+    {
+        $configuredBundleOptions = $data['bundle_options'];
+        unset($data['bundle_options']);
+
+        $bundleProduct = $this->buildSimpleProduct($data);
+        $bundleProduct->setStockData(array(
+            'use_config_manage_stock' => 0, //'Use config settings' checkbox
+            'manage_stock' => 1, //manage stock
+            'is_in_stock' => 1, //Stock Availability
+        ));
+
+        // Requires title
+        $defaultOptions = array(
+            'option_id' => '',
+            'delete' => '',
+            'type' => 'select',
+            'required' => '1',
+            'position' => '1'
+        );
+
+        $bundleOptions = array();
+        $bundleSelections = array();
+        foreach ($configuredBundleOptions as $option) {
+            $productOptions = $option['product_options'];
+            unset($option['product_options']);
+
+            $selections = array();
+            foreach ($productOptions as $productData) {
+                $simpleProduct = $this->buildSimpleProduct($productData);
+                $simpleProduct->save();
+                $selections[] = array(
+                    'product_id' => $simpleProduct->getId(),
+                    'delete' => '',
+                    'selection_price_value' => $simpleProduct->getPrice(),
+                    'selection_price_type' => 0,
+                    'selection_qty' => 1,
+                    'selection_can_change_qty' => 0,
+                    'position' => 0,
+                    'is_default' => 1
+                );
+            }
+
+            // $bundleOptions and $bundleSelections need to have parallel indicies.
+            $bundleOptions[] = array_replace_recursive($defaultOptions, $option);
+            $bundleSelections[] = $selections;
+        }
+
+        //flags for saving custom options/selections
+        $bundleProduct->setCanSaveCustomOptions(true);
+        $bundleProduct->setCanSaveBundleSelections(true);
+        $bundleProduct->setAffectBundleProductSelections(true);
+
+        //registering a product because of Mage_Bundle_Model_Selection::_beforeSave
+        Mage::register('product', $bundleProduct);
+
+        //setting the bundle options and selection data
+        $bundleProduct->setBundleOptionsData($bundleOptions);
+        $bundleProduct->setBundleSelectionsData($bundleSelections);
+
+        $bundleProduct->save();
+    }
+}

--- a/devtools_m2/php_utils/Console/Command/CreateProductCommand.php
+++ b/devtools_m2/php_utils/Console/Command/CreateProductCommand.php
@@ -23,14 +23,8 @@ class CreateProductCommand extends Command
     /** @var \Magento\Eav\Setup\EavSetupFactory */
     protected $eavSetupFactory;
 
-    /** @var \Magento\Catalog\Api\Data\ProductExtensionInterfaceFactory */
-    // protected $productExtensionFactory;
-
     /** @var \Magento\Catalog\Api\Data\ProductLinkInterface */
     protected $productLinkFactory;
-
-    /** @var \Magento\ConfigurableProduct\Api\Data\OptionInterface */
-    // protected $productOption;
 
     /** @var \Magento\Catalog\Api\ProductRepositoryInterface **/
     protected $productRepository;
@@ -41,22 +35,16 @@ class CreateProductCommand extends Command
     /** @var \Magento\Framework\App\State **/
     protected $state;
 
-    /** @var \Magento\CatalogInventory\Api\Data\StockItemInterface **/
-    // protected $stockItemFactory;
-
     public function __construct(
         \Magento\Bundle\Api\Data\LinkInterfaceFactory $bundleLinkFactory,
         \Magento\Bundle\Api\Data\OptionInterfaceFactory $bundleOptionFactory,
         \Magento\Catalog\Model\ProductFactory $catalogProductFactory,
         \Magento\Eav\Model\Config $eavConfig,
         \Magento\Eav\Setup\EavSetupFactory $eavSetupFactory,
-        // \Magento\Catalog\Api\Data\ProductExtensionInterfaceFactory $productExtensionFactory,
         \Magento\Catalog\Api\Data\ProductLinkInterfaceFactory $productLinkFactory,
-        // \Magento\ConfigurableProduct\Api\Data\OptionInterface $productOption,
         \Magento\Catalog\Api\ProductRepositoryInterface $productRepository,
         \Magento\Framework\Setup\ModuleDataSetupInterface $setup,
         \Magento\Framework\App\State $state
-        // \Magento\CatalogInventory\Api\Data\StockItemInterfaceFactory $stockItemFactory
     ) {
         parent::__construct();
 
@@ -64,14 +52,11 @@ class CreateProductCommand extends Command
         $this->bundleOptionFactory = $bundleOptionFactory;
         $this->catalogProductFactory = $catalogProductFactory;
         $this->eavConfig = $eavConfig;
-        // $this->productOption = $productOption;
         $this->eavSetupFactory = $eavSetupFactory;
-        // $this->productExtensionFactory = $productExtensionFactory;
         $this->productLinkFactory = $productLinkFactory;
         $this->productRepository = $productRepository;
         $this->setup = $setup;
         $this->state = $state;
-        // $this->stockItemFactory = $stockItemFactory;
     }
 
     /**

--- a/devtools_m2/php_utils/Console/Command/CreateProductCommand.php
+++ b/devtools_m2/php_utils/Console/Command/CreateProductCommand.php
@@ -8,55 +8,35 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class CreateProductCommand extends Command
 {
-    /** @var \Magento\Bundle\Api\Data\LinkInterfaceFactory */
-    protected $bundleLinkFactory;
-
-    /** @var \Magento\Bundle\Api\Data\OptionInterfaceFactory */
-    protected $bundleOptionFactory;
-
-    /** @var \Magento\Catalog\Model\ProductFactory */
-    protected $catalogProductFactory;
-
-    /** @var \Magento\Eav\Model\Config */
-    protected $eavConfig;
-
-    /** @var \Magento\Eav\Setup\EavSetupFactory */
-    protected $eavSetupFactory;
-
-    /** @var \Magento\Catalog\Api\Data\ProductLinkInterface */
-    protected $productLinkFactory;
-
-    /** @var \Magento\Catalog\Api\ProductRepositoryInterface **/
-    protected $productRepository;
-
-    /** @var \Magento\Framework\Setup\ModuleDataSetupInterface **/
-    protected $setup;
-
     /** @var \Magento\Framework\App\State **/
     protected $state;
 
+    /** @var \Drip\TestUtils\Creators\SimpleProductCreatorFactory **/
+    protected $simpleProductCreatorFactory;
+
+    /** @var \Drip\TestUtils\Creators\ConfigurableProductCreatorFactory **/
+    protected $configurableProductCreatorFactory;
+
+    /** @var \Drip\TestUtils\Creators\GroupedProductCreatorFactory **/
+    protected $groupedProductCreatorFactory;
+
+    /** @var \Drip\TestUtils\Creators\BundleProductCreatorFactory **/
+    protected $bundleProductCreatorFactory;
+
     public function __construct(
-        \Magento\Bundle\Api\Data\LinkInterfaceFactory $bundleLinkFactory,
-        \Magento\Bundle\Api\Data\OptionInterfaceFactory $bundleOptionFactory,
-        \Magento\Catalog\Model\ProductFactory $catalogProductFactory,
-        \Magento\Eav\Model\Config $eavConfig,
-        \Magento\Eav\Setup\EavSetupFactory $eavSetupFactory,
-        \Magento\Catalog\Api\Data\ProductLinkInterfaceFactory $productLinkFactory,
-        \Magento\Catalog\Api\ProductRepositoryInterface $productRepository,
-        \Magento\Framework\Setup\ModuleDataSetupInterface $setup,
-        \Magento\Framework\App\State $state
+        \Magento\Framework\App\State $state,
+        \Drip\TestUtils\Creators\SimpleProductCreatorFactory $simpleProductCreatorFactory,
+        \Drip\TestUtils\Creators\ConfigurableProductCreatorFactory $configurableProductCreatorFactory,
+        \Drip\TestUtils\Creators\GroupedProductCreatorFactory $groupedProductCreatorFactory,
+        \Drip\TestUtils\Creators\BundleProductCreatorFactory $bundleProductCreatorFactory
     ) {
         parent::__construct();
 
-        $this->bundleLinkFactory = $bundleLinkFactory;
-        $this->bundleOptionFactory = $bundleOptionFactory;
-        $this->catalogProductFactory = $catalogProductFactory;
-        $this->eavConfig = $eavConfig;
-        $this->eavSetupFactory = $eavSetupFactory;
-        $this->productLinkFactory = $productLinkFactory;
-        $this->productRepository = $productRepository;
-        $this->setup = $setup;
         $this->state = $state;
+        $this->simpleProductCreatorFactory = $simpleProductCreatorFactory;
+        $this->configurableProductCreatorFactory = $configurableProductCreatorFactory;
+        $this->groupedProductCreatorFactory = $groupedProductCreatorFactory;
+        $this->bundleProductCreatorFactory = $bundleProductCreatorFactory;
     }
 
     /**
@@ -84,262 +64,26 @@ class CreateProductCommand extends Command
         }
 
         $type = array_key_exists('typeId', $json) ? $json['typeId'] : '';
+        $factory = null;
         switch ($type) {
             case 'simple':
             case '':
             case null:
-                $this->productRepository->save($this->buildSimpleProduct($json));
+                $factory = $this->simpleProductCreatorFactory;
                 break;
             case 'configurable':
-                $this->buildConfigurableProduct($json);
+                $factory = $this->configurableProductCreatorFactory;
                 break;
             case 'grouped':
-                $this->buildGroupedProduct($json);
+                $factory = $this->groupedProductCreatorFactory;
                 break;
             case 'bundle':
-                $this->buildBundleProduct($json);
+                $factory = $this->bundleProductCreatorFactory;
                 break;
             default:
                 throw new \Exception("Unsupported type: ${type}");
         }
-    }
 
-    protected function buildSimpleProduct($data)
-    {
-        $product = $this->catalogProductFactory->create();
-
-        $defaultAttrSetId = $product->getDefaultAttributeSetId();
-
-        $defaults = array(
-            "storeId" => 1,
-            "websiteIds" => [1],
-            "typeId" => "simple",
-            "weight" => 4.0000,
-            "status" => 1, //product status (1 - enabled, 2 - disabled)
-            "taxClassId" => 0, //tax class (0 - none, 1 - default, 2 - taxable, 4 - shipping)
-            "price" => 11.22,
-            "cost" => 22.33,
-            "attributeSetId" => $defaultAttrSetId,
-            "createdAt" => strtotime('now'),
-            "updatedAt" => strtotime('now'),
-            "stockData" => array(
-                "use_config_manage_stock" => 0,
-                "manage_stock" => 1,
-                "is_in_stock" => 1,
-                "qty" => 999
-            ),
-        );
-        $fullData = array_replace_recursive($defaults, $data);
-
-        // This assumes that you properly name all of the attributes. But we control both ends, so it should be fine.
-        foreach ($fullData as $key => $value) {
-            $methodName = "set".ucfirst($key);
-            $product->$methodName($value);
-        }
-
-        $product->setVisibility(\Magento\Catalog\Model\Product\Visibility::VISIBILITY_BOTH); //catalog and search visibility
-
-        return $product;
-    }
-
-    protected function buildAttribute($title, $options)
-    {
-        $this->setup->startSetup();
-
-        /** @var \Magento\Eav\Setup\EavSetup $eavSetup */
-        $eavSetup = $this->eavSetupFactory->create(['setup' => $this->setup]);
-
-        $eavSetup->addAttribute('catalog_product', $title, array(
-            'group' => 'General',
-            'label' => $title,
-            'input' => 'select',
-            'type' => 'varchar',
-            'required' => 0,
-            'visible_on_front' => false,
-            'filterable' => 0,
-            'filterable_in_search' => 0,
-            'searchable' => 0,
-            'used_in_product_listing' => true,
-            'visible_in_advanced_search' => false,
-            'comparable' => 0,
-            'user_defined' => 1,
-            'is_configurable' => 0,
-            'global' => \Magento\Eav\Model\Entity\Attribute\ScopedAttributeInterface::SCOPE_GLOBAL,
-            'option' => array('values' => $options),
-            'note' => '',
-        ));
-
-        $this->setup->endSetup();
-
-        // Obtain and return the attribute.
-        return $this->eavConfig->getAttribute('catalog_product', $title);
-    }
-
-    protected function buildConfigurableProduct($data)
-    {
-        $attributes = $data['attributes'];
-        unset($data['attributes']);
-
-        $configProduct = $this->buildSimpleProduct($data);
-        $configProduct->setStockData(array(
-            'use_config_manage_stock' => 0, //'Use config settings' checkbox
-            'manage_stock' => 1, //manage stock
-            'is_in_stock' => 1, //Stock Availability
-        ));
-
-        $attributeIds = array();
-        $configurableAttributesData = array();
-        // $configurableProductsData = array();
-        $associatedProductIds = array();
-
-        foreach ($attributes as $attrName => $attrValues) {
-            $attribute = $this->buildAttribute($attrName, array_keys($attrValues));
-            $attributeIds[] = $attribute->getId();
-
-            $attributeValues = array();
-
-            foreach ($attrValues as $option => $simpleProductData) {
-                $simpleProduct = $this->buildSimpleProduct($simpleProductData);
-                $simpleProduct->setVisibility(\Magento\Catalog\Model\Product\Visibility::VISIBILITY_NOT_VISIBLE);
-                $optionId = $attribute->setStoreId(0)->getSource()->getOptionId($option);
-                $simpleProduct->setData($attrName, $optionId);
-                $simpleProduct = $this->productRepository->save($simpleProduct);
-                $associatedProductIds[] = $simpleProduct->getId();
-
-                $attributeValues[] = [
-                    'label' => $option,
-                    'attribute_id' => $attribute->getId(),
-                    'value_index' => $optionId,
-                ];
-            }
-
-            $configurableAttributesData[] = array(
-                'attribute_id' => $attribute->getId(),
-                'code' => $attribute->getAttributeCode(),
-                'label' => $attribute->getStoreLabel(),
-                'position' => '0',
-                'values' => $attributeValues,
-            );
-        }
-
-
-        // All the documentation says not to use object manager. But not using object manager breaks in weird ways.
-        // This is test harness code. I don't care.
-        $ob = \Magento\Framework\App\ObjectManager::getInstance();
-        $optionsFactory = $ob->create(\Magento\ConfigurableProduct\Helper\Product\Options\Factory::class);
-
-        $configurableOptions = $optionsFactory->create($configurableAttributesData);
-
-        $extensionConfigurableAttributes = $configProduct->getExtensionAttributes();
-        $extensionConfigurableAttributes->setConfigurableProductOptions($configurableOptions);
-        $extensionConfigurableAttributes->setConfigurableProductLinks($associatedProductIds);
-        $configProduct->setExtensionAttributes($extensionConfigurableAttributes);
-
-        $this->productRepository->save($configProduct);
-    }
-
-    protected function buildGroupedProduct($data)
-    {
-        $associated = $data['associated'];
-        unset($data['associated']);
-
-        $groupedProduct = $this->buildSimpleProduct($data);
-        $groupedProduct->setStockData(array(
-            'use_config_manage_stock' => 0, //'Use config settings' checkbox
-            'manage_stock' => 1, //manage stock
-            'is_in_stock' => 1, //Stock Availability
-        ));
-        // This save mostly happens in order to keep the product creation in
-        // the same order as the M1 test suite. This makes things more
-        // consistent.
-        $this->productRepository->save($groupedProduct);
-
-        $productLinks = array();
-
-        foreach ($associated as $simpleProductData) {
-            $simpleProduct = $this->buildSimpleProduct($simpleProductData);
-            $this->productRepository->save($simpleProduct);
-
-            $productLink = $this->productLinkFactory->create();
-
-            $productLink->setSku($groupedProduct->getSku())
-                ->setLinkType('associated')
-                ->setLinkedProductSku($simpleProduct->getSku())
-                ->setLinkedProductType($simpleProduct->getTypeId())
-                ->getExtensionAttributes()
-                ->setQty(0);
-
-            $productLinks[] = $productLink;
-        }
-
-        $groupedProduct->setProductLinks($productLinks);
-
-        $this->productRepository->save($groupedProduct);
-    }
-
-    protected function buildBundleProduct($data)
-    {
-        $configuredBundleOptions = $data['bundle_options'];
-        unset($data['bundle_options']);
-
-        $bundleProduct = $this->buildSimpleProduct($data);
-        $bundleProduct->setStockData(array(
-            'use_config_manage_stock' => 0, //'Use config settings' checkbox
-            'manage_stock' => 1, //manage stock
-            'is_in_stock' => 1, //Stock Availability
-        ));
-
-        // Requires title
-        $defaultOptions = array(
-            'delete' => '',
-            'type' => 'select',
-            'required' => '1'
-        );
-
-        $extOptions = [];
-        foreach ($configuredBundleOptions as $option) {
-            $productOptions = $option['product_options'];
-            unset($option['product_options']);
-
-            $links = array();
-            foreach ($productOptions as $productData) {
-                $simpleProduct = $this->buildSimpleProduct($productData);
-                $this->productRepository->save($simpleProduct);
-                $bundleSelection = array(
-                    'product_id' => $simpleProduct->getId(),
-                    'delete' => '',
-                    'selection_price_value' => $simpleProduct->getPrice(),
-                    'selection_qty' => 1,
-                    'selection_can_change_qty' => 0
-                );
-
-                /** @var \Magento\Bundle\Api\Data\LinkInterface $link */
-                $link = $this->bundleLinkFactory->create(['data' => $bundleSelection]);
-                $link->setSku($simpleProduct->getSku());
-                $link->setQty($bundleSelection['selection_qty']);
-                $link->setPrice($bundleSelection['selection_price_value']);
-                if (isset($bundleSelection['selection_can_change_qty'])) {
-                    $link->setCanChangeQuantity($bundleSelection['selection_can_change_qty']);
-                }
-                $links[] = $link;
-            }
-
-            $optionData = array_replace_recursive($defaultOptions, $option);
-
-            $extOption = $this->bundleOptionFactory->create(['data' => $optionData]);
-            $extOption->setSku($bundleProduct->getSku());
-            $extOption->setOptionId(null);
-            $extOption->setProductLinks($links);
-
-            $extOptions[] = $extOption;
-        }
-
-        $extension = $bundleProduct->getExtensionAttributes();
-        $extension->setBundleProductOptions($extOptions);
-        $bundleProduct->setExtensionAttributes($extension);
-
-        $bundleProduct->setPriceView(1);
-
-        $this->productRepository->save($bundleProduct);
+        $factory->create(['productData' => $json])->create();
     }
 }

--- a/devtools_m2/php_utils/Creators/BundleProductCreator.php
+++ b/devtools_m2/php_utils/Creators/BundleProductCreator.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Drip\TestUtils\Creators;
+
+class BundleProductCreator
+{
+    /** @var \Magento\Catalog\Api\ProductRepositoryInterface **/
+    protected $productRepository;
+
+    /** @var \Drip\TestUtils\Creators\SimpleProductCreatorFactory **/
+    protected $simpleProductCreatorFactory;
+
+    /** @var \Magento\Bundle\Api\Data\LinkInterfaceFactory */
+    protected $bundleLinkFactory;
+
+    /** @var \Magento\Bundle\Api\Data\OptionInterfaceFactory */
+    protected $bundleOptionFactory;
+
+    public function __construct(
+        \Magento\Catalog\Api\ProductRepositoryInterface $productRepository,
+        \Drip\TestUtils\Creators\SimpleProductCreatorFactory $simpleProductCreatorFactory,
+        \Magento\Bundle\Api\Data\LinkInterfaceFactory $bundleLinkFactory,
+        \Magento\Bundle\Api\Data\OptionInterfaceFactory $bundleOptionFactory,
+        $productData
+    ) {
+        $this->productRepository = $productRepository;
+        $this->simpleProductCreatorFactory = $simpleProductCreatorFactory;
+        $this->bundleLinkFactory = $bundleLinkFactory;
+        $this->bundleOptionFactory = $bundleOptionFactory;
+        $this->productData = $productData;
+    }
+
+    public function create()
+    {
+        $configuredBundleOptions = $this->productData['bundle_options'];
+        unset($this->productData['bundle_options']);
+
+        $bundleProduct = $this->simpleProductCreatorFactory->create(['productData' => $this->productData])->build();
+        $bundleProduct->setStockData(array(
+            'use_config_manage_stock' => 0, //'Use config settings' checkbox
+            'manage_stock' => 1, //manage stock
+            'is_in_stock' => 1, //Stock Availability
+        ));
+
+        // Requires title
+        $defaultOptions = array(
+            'delete' => '',
+            'type' => 'select',
+            'required' => '1'
+        );
+
+        $extOptions = [];
+        foreach ($configuredBundleOptions as $option) {
+            $productOptions = $option['product_options'];
+            unset($option['product_options']);
+
+            $links = array();
+            foreach ($productOptions as $productData) {
+                $simpleProduct = $this->simpleProductCreatorFactory->create(['productData' => $productData])->build();
+                $this->productRepository->save($simpleProduct);
+                $bundleSelection = array(
+                    'product_id' => $simpleProduct->getId(),
+                    'delete' => '',
+                    'selection_price_value' => $simpleProduct->getPrice(),
+                    'selection_qty' => 1,
+                    'selection_can_change_qty' => 0
+                );
+
+                /** @var \Magento\Bundle\Api\Data\LinkInterface $link */
+                $link = $this->bundleLinkFactory->create(['data' => $bundleSelection]);
+                $link->setSku($simpleProduct->getSku());
+                $link->setQty($bundleSelection['selection_qty']);
+                $link->setPrice($bundleSelection['selection_price_value']);
+                if (isset($bundleSelection['selection_can_change_qty'])) {
+                    $link->setCanChangeQuantity($bundleSelection['selection_can_change_qty']);
+                }
+                $links[] = $link;
+            }
+
+            $optionData = array_replace_recursive($defaultOptions, $option);
+
+            $extOption = $this->bundleOptionFactory->create(['data' => $optionData]);
+            $extOption->setSku($bundleProduct->getSku());
+            $extOption->setOptionId(null);
+            $extOption->setProductLinks($links);
+
+            $extOptions[] = $extOption;
+        }
+
+        $extension = $bundleProduct->getExtensionAttributes();
+        $extension->setBundleProductOptions($extOptions);
+        $bundleProduct->setExtensionAttributes($extension);
+
+        $bundleProduct->setPriceView(1);
+
+        $this->productRepository->save($bundleProduct);
+    }
+}

--- a/devtools_m2/php_utils/Creators/ConfigurableProductCreator.php
+++ b/devtools_m2/php_utils/Creators/ConfigurableProductCreator.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Drip\TestUtils\Creators;
+
+class ConfigurableProductCreator
+{
+    /** @var \Magento\Catalog\Api\ProductRepositoryInterface **/
+    protected $productRepository;
+
+    /** @var \Drip\TestUtils\Creators\SimpleProductCreatorFactory **/
+    protected $simpleProductCreatorFactory;
+
+    /** @var \Magento\Eav\Model\Config */
+    protected $eavConfig;
+
+    /** @var \Magento\Eav\Setup\EavSetupFactory */
+    protected $eavSetupFactory;
+
+    /** @var \Magento\Framework\Setup\ModuleDataSetupInterface **/
+    protected $setup;
+
+    public function __construct(
+        \Magento\Catalog\Api\ProductRepositoryInterface $productRepository,
+        \Drip\TestUtils\Creators\SimpleProductCreatorFactory $simpleProductCreatorFactory,
+        \Magento\Framework\Setup\ModuleDataSetupInterface $setup,
+        \Magento\Eav\Model\Config $eavConfig,
+        \Magento\Eav\Setup\EavSetupFactory $eavSetupFactory,
+        $productData
+    ) {
+        $this->productRepository = $productRepository;
+        $this->simpleProductCreatorFactory = $simpleProductCreatorFactory;
+        $this->setup = $setup;
+        $this->eavConfig = $eavConfig;
+        $this->eavSetupFactory = $eavSetupFactory;
+        $this->productData = $productData;
+    }
+
+    public function create()
+    {
+        $attributes = $this->productData['attributes'];
+        unset($this->productData['attributes']);
+
+        $configProduct = $this->simpleProductCreatorFactory->create(['productData' => $this->productData])->build();
+        $configProduct->setStockData(array(
+            'use_config_manage_stock' => 0, //'Use config settings' checkbox
+            'manage_stock' => 1, //manage stock
+            'is_in_stock' => 1, //Stock Availability
+        ));
+
+        $attributeIds = array();
+        $configurableAttributesData = array();
+        // $configurableProductsData = array();
+        $associatedProductIds = array();
+
+        foreach ($attributes as $attrName => $attrValues) {
+            $attribute = $this->buildAttribute($attrName, array_keys($attrValues));
+            $attributeIds[] = $attribute->getId();
+
+            $attributeValues = array();
+
+            foreach ($attrValues as $option => $simpleProductData) {
+                $simpleProduct = $this->simpleProductCreatorFactory->create(['productData' => $simpleProductData])->build();
+                $simpleProduct->setVisibility(\Magento\Catalog\Model\Product\Visibility::VISIBILITY_NOT_VISIBLE);
+                $optionId = $attribute->setStoreId(0)->getSource()->getOptionId($option);
+                $simpleProduct->setData($attrName, $optionId);
+                $simpleProduct = $this->productRepository->save($simpleProduct);
+                $associatedProductIds[] = $simpleProduct->getId();
+
+                $attributeValues[] = [
+                    'label' => $option,
+                    'attribute_id' => $attribute->getId(),
+                    'value_index' => $optionId,
+                ];
+            }
+
+            $configurableAttributesData[] = array(
+                'attribute_id' => $attribute->getId(),
+                'code' => $attribute->getAttributeCode(),
+                'label' => $attribute->getStoreLabel(),
+                'position' => '0',
+                'values' => $attributeValues,
+            );
+        }
+
+
+        // All the documentation says not to use object manager. But not using object manager breaks in weird ways.
+        // This is test harness code. I don't care.
+        $ob = \Magento\Framework\App\ObjectManager::getInstance();
+        $optionsFactory = $ob->create(\Magento\ConfigurableProduct\Helper\Product\Options\Factory::class);
+
+        $configurableOptions = $optionsFactory->create($configurableAttributesData);
+
+        $extensionConfigurableAttributes = $configProduct->getExtensionAttributes();
+        $extensionConfigurableAttributes->setConfigurableProductOptions($configurableOptions);
+        $extensionConfigurableAttributes->setConfigurableProductLinks($associatedProductIds);
+        $configProduct->setExtensionAttributes($extensionConfigurableAttributes);
+
+        $this->productRepository->save($configProduct);
+    }
+
+    protected function buildAttribute($title, $options)
+    {
+        $this->setup->startSetup();
+
+        /** @var \Magento\Eav\Setup\EavSetup $eavSetup */
+        $eavSetup = $this->eavSetupFactory->create(['setup' => $this->setup]);
+
+        $eavSetup->addAttribute('catalog_product', $title, array(
+            'group' => 'General',
+            'label' => $title,
+            'input' => 'select',
+            'type' => 'varchar',
+            'required' => 0,
+            'visible_on_front' => false,
+            'filterable' => 0,
+            'filterable_in_search' => 0,
+            'searchable' => 0,
+            'used_in_product_listing' => true,
+            'visible_in_advanced_search' => false,
+            'comparable' => 0,
+            'user_defined' => 1,
+            'is_configurable' => 0,
+            'global' => \Magento\Eav\Model\Entity\Attribute\ScopedAttributeInterface::SCOPE_GLOBAL,
+            'option' => array('values' => $options),
+            'note' => '',
+        ));
+
+        $this->setup->endSetup();
+
+        // Obtain and return the attribute.
+        return $this->eavConfig->getAttribute('catalog_product', $title);
+    }
+}

--- a/devtools_m2/php_utils/Creators/GroupedProductCreator.php
+++ b/devtools_m2/php_utils/Creators/GroupedProductCreator.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Drip\TestUtils\Creators;
+
+class GroupedProductCreator
+{
+    /** @var \Magento\Catalog\Api\ProductRepositoryInterface **/
+    protected $productRepository;
+
+    /** @var \Drip\TestUtils\Creators\SimpleProductCreatorFactory **/
+    protected $simpleProductCreatorFactory;
+
+    /** @var \Magento\Catalog\Api\Data\ProductLinkInterface */
+    protected $productLinkFactory;
+
+    public function __construct(
+        \Magento\Catalog\Api\ProductRepositoryInterface $productRepository,
+        \Drip\TestUtils\Creators\SimpleProductCreatorFactory $simpleProductCreatorFactory,
+        \Magento\Catalog\Api\Data\ProductLinkInterfaceFactory $productLinkFactory,
+        $productData
+    ) {
+        $this->productRepository = $productRepository;
+        $this->simpleProductCreatorFactory = $simpleProductCreatorFactory;
+        $this->productLinkFactory = $productLinkFactory;
+        $this->productData = $productData;
+    }
+
+    public function create()
+    {
+        $associated = $this->productData['associated'];
+        unset($this->productData['associated']);
+
+        $groupedProduct = $this->simpleProductCreatorFactory->create(['productData' => $this->productData])->build();
+        $groupedProduct->setStockData(array(
+            'use_config_manage_stock' => 0, //'Use config settings' checkbox
+            'manage_stock' => 1, //manage stock
+            'is_in_stock' => 1, //Stock Availability
+        ));
+        // This save mostly happens in order to keep the product creation in
+        // the same order as the M1 test suite. This makes things more
+        // consistent.
+        $this->productRepository->save($groupedProduct);
+
+        $productLinks = array();
+
+        foreach ($associated as $simpleProductData) {
+            $simpleProduct = $this->simpleProductCreatorFactory->create(['productData' => $simpleProductData])->build();
+            $this->productRepository->save($simpleProduct);
+
+            $productLink = $this->productLinkFactory->create();
+
+            $productLink->setSku($groupedProduct->getSku())
+                ->setLinkType('associated')
+                ->setLinkedProductSku($simpleProduct->getSku())
+                ->setLinkedProductType($simpleProduct->getTypeId())
+                ->getExtensionAttributes()
+                ->setQty(0);
+
+            $productLinks[] = $productLink;
+        }
+
+        $groupedProduct->setProductLinks($productLinks);
+
+        $this->productRepository->save($groupedProduct);
+    }
+}

--- a/devtools_m2/php_utils/Creators/SimpleProductCreator.php
+++ b/devtools_m2/php_utils/Creators/SimpleProductCreator.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Drip\TestUtils\Creators;
+
+class SimpleProductCreator
+{
+    /** @var \Magento\Catalog\Model\ProductFactory */
+    protected $catalogProductFactory;
+
+    /** @var \Magento\Catalog\Api\ProductRepositoryInterface **/
+    protected $productRepository;
+
+    public function __construct(
+        \Magento\Catalog\Model\ProductFactory $catalogProductFactory,
+        \Magento\Catalog\Api\ProductRepositoryInterface $productRepository,
+        $productData
+    ) {
+        $this->catalogProductFactory = $catalogProductFactory;
+        $this->productRepository = $productRepository;
+        $this->productData = $productData;
+    }
+
+    public function create()
+    {
+        $this->productRepository->save($this->build());
+    }
+
+    public function build()
+    {
+        $product = $this->catalogProductFactory->create();
+
+        $defaultAttrSetId = $product->getDefaultAttributeSetId();
+
+        $defaults = array(
+            "storeId" => 1,
+            "websiteIds" => [1],
+            "typeId" => "simple",
+            "weight" => 4.0000,
+            "status" => 1, //product status (1 - enabled, 2 - disabled)
+            "taxClassId" => 0, //tax class (0 - none, 1 - default, 2 - taxable, 4 - shipping)
+            "price" => 11.22,
+            "cost" => 22.33,
+            "attributeSetId" => $defaultAttrSetId,
+            "createdAt" => strtotime('now'),
+            "updatedAt" => strtotime('now'),
+            "stockData" => array(
+                "use_config_manage_stock" => 0,
+                "manage_stock" => 1,
+                "is_in_stock" => 1,
+                "qty" => 999
+            ),
+        );
+        $fullData = array_replace_recursive($defaults, $this->productData);
+
+        // This assumes that you properly name all of the attributes. But we control both ends, so it should be fine.
+        foreach ($fullData as $key => $value) {
+            $methodName = "set".ucfirst($key);
+            $product->$methodName($value);
+        }
+
+        $product->setVisibility(\Magento\Catalog\Model\Product\Visibility::VISIBILITY_BOTH); //catalog and search visibility
+
+        return $product;
+    }
+}

--- a/devtools_m2/php_utils/composer.json
+++ b/devtools_m2/php_utils/composer.json
@@ -1,0 +1,18 @@
+{
+  "name": "drip/test_utils",
+  "description": "Testing scripts",
+  "require": {
+    "php": "~5.6.0|~7.0.0"
+  },
+  "type": "magento2-module",
+  "version": "1.1.7",
+  "license": [
+    "OSL-3.0"
+  ],
+  "autoload": {
+    "files": [ "registration.php" ],
+    "psr-4": {
+      "Drip\\TestUtils\\": ""
+    }
+  }
+}

--- a/devtools_m2/php_utils/etc/di.xml
+++ b/devtools_m2/php_utils/etc/di.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Framework\Console\CommandListInterface">
+        <arguments>
+            <argument name="commands" xsi:type="array">
+                <item name="driptestutils_createproduct" xsi:type="object">Drip\TestUtils\Console\Command\CreateProductCommand</item>
+            </argument>
+        </arguments>
+    </type>
+</config>

--- a/devtools_m2/php_utils/etc/module.xml
+++ b/devtools_m2/php_utils/etc/module.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+  <module name="Drip_TestUtils" setup_version="1.0.0">
+    <sequence>
+    </sequence>
+  </module>
+</config>

--- a/devtools_m2/php_utils/registration.php
+++ b/devtools_m2/php_utils/registration.php
@@ -1,0 +1,6 @@
+<?php
+\Magento\Framework\Component\ComponentRegistrar::register(
+    \Magento\Framework\Component\ComponentRegistrar::MODULE,
+    'Drip_TestUtils',
+    __DIR__
+);

--- a/view/adminhtml/templates/system/config/sync/customers.phtml
+++ b/view/adminhtml/templates/system/config/sync/customers.phtml
@@ -36,14 +36,15 @@ require(
             if (options.inprogress) {
                 return;
             }
+
             $.ajax({
                 url: '<?=$block->getAjaxUrl()?>',
                 type: 'post',
                 context: this,
                 data: {
                     form_key: window.FORM_KEY,
-                    store_id: <?=$block->getStoreId()?>,
-                    account_id: <?=$block->getAccountId()?>
+                    store_id: <?= json_encode($block->getStoreId())?>,
+                    account_id: <?=json_encode($block->getAccountId())?>
                 },
                 dataType: 'json',
                 beforeSend: _ajaxBeforeSend,

--- a/view/adminhtml/templates/system/config/sync/customers/reset.phtml
+++ b/view/adminhtml/templates/system/config/sync/customers/reset.phtml
@@ -38,8 +38,8 @@ require(
                 context: this,
                 data: {
                     form_key: window.FORM_KEY,
-                    store_id: <?=$block->getStoreId()?>,
-                    account_id: <?=$block->getAccountId()?>
+                    store_id: <?=json_encode($block->getStoreId())?>,
+                    account_id: <?=json_encode($block->getAccountId())?>
                 },
                 dataType: 'json',
                 beforeSend: _ajaxBeforeSend,

--- a/view/adminhtml/templates/system/config/sync/orders.phtml
+++ b/view/adminhtml/templates/system/config/sync/orders.phtml
@@ -42,8 +42,8 @@ require(
                 context: this,
                 data: {
                     form_key: window.FORM_KEY,
-                    store_id: <?=$block->getStoreId()?>,
-                    account_id: <?=$block->getAccountId()?>
+                    store_id: <?=json_encode($block->getStoreId())?>,
+                    account_id: <?=json_encode($block->getAccountId())?>
                 },
                 dataType: 'json',
                 beforeSend: _ajaxBeforeSend,

--- a/view/adminhtml/templates/system/config/sync/orders/reset.phtml
+++ b/view/adminhtml/templates/system/config/sync/orders/reset.phtml
@@ -38,8 +38,8 @@ require(
                 context: this,
                 data: {
                     form_key: window.FORM_KEY,
-                    store_id: <?=$block->getStoreId()?>,
-                    account_id: <?=$block->getAccountId()?>
+                    store_id: <?=json_encode($block->getStoreId())?>,
+                    account_id: <?=json_encode($block->getAccountId())?>
                 },
                 dataType: 'json',
                 beforeSend: _ajaxBeforeSend,


### PR DESCRIPTION
Port of https://github.com/DripEmail/magento-m1-extension/pull/11

Ports everything from the prior PR, plus the following:

- Fixes addresses in orders, which weren't working at all in M2 before now…
- In M1, I could just create a command line script. In M2, I have to create a module, add command objects, and then register them with the app. So that's more complicated…
- I had to create an afterEach for the tests, since XHR requests were bleeding over between tests and breaking the beforeEach blocks. M2 uses AJAX a heck of a lot more than M1, so this wasn't necessary in the latter.
- Added some json escaping, since null was getting coerced into empty string and caused JS breakage. The tests actually caught this one!
