### PR TITLE
mockserver 5.7.0 for now

### DIFF
--- a/devtools_m2/docker-compose.test.yml
+++ b/devtools_m2/docker-compose.test.yml
@@ -10,6 +10,6 @@ services:
   db:
     tmpfs: /var/lib/mysql
   mock:
-    image: jamesdbloom/mockserver
+    image: jamesdbloom/mockserver:mockserver-5.7.0
     ports:
     - 1080:1080


### PR DESCRIPTION
5.7.1 has a bug that breaks some of our tests: https://github.com/jamesdbloom/mockserver/issues/685