### PR TITLE
Port frontend multi-store tests to M2 ECI-156

### DIFF
--- a/devtools_m2/cypress/integration/CustomerCartInteractions.feature
+++ b/devtools_m2/cypress/integration/CustomerCartInteractions.feature
@@ -5,7 +5,7 @@ Feature: Customer Cart Interactions
   Scenario: A customer adds a simple product to their cart
     Given I am logged into the admin interface
       And I have configured Drip to be enabled for 'main'
-    Given I have configured a simple widget
+    Given I have configured a simple widget for 'main'
     When I open the 'main' homepage
       And I create an account
       And I add a 'simple' widget to my cart
@@ -58,3 +58,27 @@ Feature: Customer Cart Interactions
     Then A bundle cart event should be sent to Drip
     When I check out
     Then A bundle order event should be sent to Drip
+
+  Scenario: A customer adds a simple product to their cart when only that store is configured for Drip
+    Given I am logged into the admin interface
+      And I have set up a multi-store configuration
+      And I have configured Drip to be enabled for 'site1'
+      And I have configured a simple widget for 'site1'
+    When I open the 'site1' homepage
+      And I create an account
+      And I add a 'simple' widget to my cart
+    Then A simple cart event should be sent to Drip
+    When I check out
+    Then A simple order event should be sent to Drip
+
+  Scenario: A customer adds a simple product to their cart when a different store is configured for Drip
+    Given I am logged into the admin interface
+      And I have set up a multi-store configuration
+      And I have configured Drip to be enabled for 'site1'
+      And I have configured a simple widget for 'main'
+    When I open the 'main' homepage
+      And I create an account
+      And I add a 'simple' widget to my cart
+    Then No web requests are sent
+    When I check out
+    Then No web requests are sent

--- a/devtools_m2/cypress/integration/CustomerCartInteractions/steps.js
+++ b/devtools_m2/cypress/integration/CustomerCartInteractions/steps.js
@@ -1,5 +1,6 @@
 import { Given, When, Then } from "cypress-cucumber-preprocessor/steps"
 import { mockServerClient } from "mockserver-client"
+import { getCurrentFrontendDomain, getCurrentFrontendWebsiteId, getCurrentFrontendSite } from "../../lib/frontend_context"
 
 const Mockclient = mockServerClient("localhost", 1080);
 
@@ -17,7 +18,7 @@ When('I create an account', function() {
 
 When('I add a {string} widget to my cart', function(type) {
   cy.route('POST', 'checkout/cart/add/**').as('addToCartRequest')
-  cy.visit(`/widget-1.html`)
+  cy.visit(`${getCurrentFrontendDomain()}/widget-1.html`)
   switch (type) {
     case 'configurable':
       cy.get('#product-options-wrapper select').select('XL')
@@ -47,7 +48,7 @@ When('I add a {string} widget to my cart', function(type) {
 // TODO: This is kind of ugly and duplicates the prior.
 When('I add a different {string} widget to my cart', function(type) {
   cy.route('POST', 'checkout/cart/add/**').as('addToCartRequest')
-  cy.visit(`/widget-1.html`)
+  cy.visit(`${getCurrentFrontendDomain()}/widget-1.html`)
   switch (type) {
     case 'configurable':
       cy.get('#product-options-wrapper select').select('L')
@@ -79,7 +80,7 @@ Then('A simple cart event should be sent to Drip', function() {
     expect(body.email).to.eq('testuser@example.com')
     expect(body.action).to.eq('created')
     expect(body.cart_id).to.eq('1')
-    expect(body.cart_url).to.startWith('http://main.magento.localhost:3006/drip/cart/index/q/1')
+    expect(body.cart_url).to.startWith(`${getCurrentFrontendDomain()}/drip/cart/index/q/1`)
     expect(body.currency).to.eq('USD')
     expect(body.grand_total).to.eq(11.22)
     expect(body.initial_status).to.eq('unsubscribed')
@@ -96,10 +97,10 @@ Then('A simple cart event should be sent to Drip', function() {
     expect(item.sku).to.eq('widg-1')
     expect(item.categories).to.be.empty
     expect(item.discounts).to.eq(0)
-    expect(item.image_url).to.eq('http://main.magento.localhost:3006/pub/media/catalog/product/')
+    expect(item.image_url).to.eq(`${getCurrentFrontendDomain()}/pub/media/catalog/product/`)
     expect(item.name).to.eq('Widget 1')
     expect(item.price).to.eq(11.22)
-    expect(item.product_url).to.eq('http://main.magento.localhost:3006/widget-1.html')
+    expect(item.product_url).to.eq(`${getCurrentFrontendDomain()}/widget-1.html`)
     expect(item.quantity).to.eq(1)
     expect(item.total).to.eq(11.22)
   })
@@ -115,7 +116,7 @@ Then('A configurable cart event should be sent to Drip', function() {
     expect(body.email).to.eq('testuser@example.com')
     expect(body.action).to.eq('created')
     expect(body.cart_id).to.eq('1')
-    expect(body.cart_url).to.startWith('http://main.magento.localhost:3006/drip/cart/index/q/1')
+    expect(body.cart_url).to.startWith(`${getCurrentFrontendDomain()}/drip/cart/index/q/1`)
     expect(body.currency).to.eq('USD')
     expect(body.grand_total).to.eq(11.22)
     expect(body.initial_status).to.eq('unsubscribed')
@@ -132,10 +133,10 @@ Then('A configurable cart event should be sent to Drip', function() {
     expect(item.sku).to.eq('widg-1-xl')
     expect(item.categories).to.be.empty
     expect(item.discounts).to.eq(0)
-    expect(item.image_url).to.eq('http://main.magento.localhost:3006/pub/media/catalog/product/')
+    expect(item.image_url).to.eq(`${getCurrentFrontendDomain()}/pub/media/catalog/product/`)
     expect(item.name).to.eq('Widget 1') // TODO: Figure out whether this is correct.
     expect(item.price).to.eq(11.22)
-    expect(item.product_url).to.eq('http://main.magento.localhost:3006/widget-1.html')
+    expect(item.product_url).to.eq(`${getCurrentFrontendDomain()}/widget-1.html`)
     expect(item.quantity).to.eq(1)
     expect(item.total).to.eq(11.22)
   })
@@ -171,7 +172,7 @@ Then('A grouped cart event should be sent to Drip', function() {
     expect(body.email).to.eq('testuser@example.com')
     expect(body.action).to.eq('created')
     expect(body.cart_id).to.eq('1')
-    expect(body.cart_url).to.startWith('http://main.magento.localhost:3006/drip/cart/index/q/1')
+    expect(body.cart_url).to.startWith(`${getCurrentFrontendDomain()}/drip/cart/index/q/1`)
     expect(body.currency).to.eq('USD')
     expect(body.grand_total).to.eq(22.44)
     expect(body.initial_status).to.eq('unsubscribed')
@@ -189,13 +190,13 @@ Then('A grouped cart event should be sent to Drip', function() {
           expect(item.product_id).to.eq('2')
           expect(item.product_variant_id).to.eq('2')
           expect(item.name).to.eq('Widget 1 Sub 1')
-          expect(item.product_url).to.eq('http://main.magento.localhost:3006/widget-1-sub-1.html')
+          expect(item.product_url).to.eq(`${getCurrentFrontendDomain()}/widget-1-sub-1.html`)
           break;
         case 'widg-1-sub2':
           expect(item.product_id).to.eq('3')
           expect(item.product_variant_id).to.eq('3')
           expect(item.name).to.eq('Widget 1 Sub 2')
-          expect(item.product_url).to.eq('http://main.magento.localhost:3006/widget-1-sub-2.html')
+          expect(item.product_url).to.eq(`${getCurrentFrontendDomain()}/widget-1-sub-2.html`)
           break;
         default:
           expect.fail(`Unknown SKU: ${item.sku}`)
@@ -203,7 +204,7 @@ Then('A grouped cart event should be sent to Drip', function() {
       }
       expect(item.categories).to.be.empty
       expect(item.discounts).to.eq(0)
-      expect(item.image_url).to.eq('http://main.magento.localhost:3006/pub/media/catalog/product/')
+      expect(item.image_url).to.eq(`${getCurrentFrontendDomain()}/pub/media/catalog/product/`)
       expect(item.price).to.eq(11.22)
       expect(item.quantity).to.eq(1)
       expect(item.total).to.eq(11.22)
@@ -221,7 +222,7 @@ Then('A bundle cart event should be sent to Drip', function() {
     expect(body.email).to.eq('testuser@example.com')
     expect(body.action).to.eq('created')
     expect(body.cart_id).to.eq('1')
-    expect(body.cart_url).to.startWith('http://main.magento.localhost:3006/drip/cart/index/q/1')
+    expect(body.cart_url).to.startWith(`${getCurrentFrontendDomain()}/drip/cart/index/q/1`)
     expect(body.currency).to.eq('USD')
     expect(body.grand_total).to.eq(22.44)
     expect(body.initial_status).to.eq('unsubscribed')
@@ -239,10 +240,10 @@ Then('A bundle cart event should be sent to Drip', function() {
     expect(item.sku).to.eq('widg-1')
     expect(item.categories).to.be.empty
     expect(item.discounts).to.eq(0)
-    expect(item.image_url).to.eq('http://main.magento.localhost:3006/pub/media/catalog/product/')
+    expect(item.image_url).to.eq(`${getCurrentFrontendDomain()}/pub/media/catalog/product/`)
     expect(item.name).to.eq('Widget 1')
     expect(item.price).to.eq(22.44)
-    expect(item.product_url).to.eq('http://main.magento.localhost:3006/widget-1.html')
+    expect(item.product_url).to.eq(`${getCurrentFrontendDomain()}/widget-1.html`)
     expect(item.quantity).to.eq(1)
     expect(item.total).to.eq(22.44)
   })
@@ -252,8 +253,21 @@ When('I check out', function() {
   cy.log('Resetting mocks')
   cy.wrap(Mockclient.reset())
 
-  cy.route('POST', 'rest/default/V1/carts/**').as('cartBuilder')
-  cy.visit('/checkout/cart')
+  // TODO: Extract this into the frontend_context file.
+  const currentSite = getCurrentFrontendSite()
+  let storeViewCode;
+  switch (currentSite) {
+    case 'site1':
+      storeViewCode = 'site1_store_view'
+      break;
+    case 'main':
+      storeViewCode = 'default'
+      break;
+    default:
+      throw 'Methinks thou hast forgotten something…'
+  }
+  cy.route('POST', `rest/${storeViewCode}/V1/carts/**`).as('cartBuilder')
+  cy.visit(`${getCurrentFrontendDomain()}/checkout/cart`)
   cy.wait('@cartBuilder', { requestTimeout: 10000 })
   cy.get('button[data-role="proceed-to-checkout"]').click()
 
@@ -272,11 +286,16 @@ When('I check out', function() {
 })
 
 function basicOrderBodyAssertions(body) {
+  let websiteId = getCurrentFrontendWebsiteId()
+  if (websiteId == 1) {
+    websiteId = ''
+  }
+
   expect(body.currency).to.eq('USD')
   expect(body.magento_source).to.eq('Storefront')
   expect(body.occurred_at).to.match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/)
-  expect(body.order_id).to.eq('000000001')
-  expect(body.order_public_id).to.eq('000000001')
+  expect(body.order_id).to.eq(`${websiteId}000000001`)
+  expect(body.order_public_id).to.eq(`${websiteId}000000001`)
   expect(body.provider).to.eq('magento')
   expect(body.total_discounts).to.eq(0)
   expect(body.total_taxes).to.eq(0)
@@ -325,12 +344,12 @@ Then('A simple order event should be sent to Drip', function() {
     const item = body.items[0]
     expect(item.categories).to.be.empty
     expect(item.discounts).to.eq(0)
-    expect(item.image_url).to.eq('http://main.magento.localhost:3006/pub/media/catalog/product/')
+    expect(item.image_url).to.eq(`${getCurrentFrontendDomain()}/pub/media/catalog/product/`)
     expect(item.name).to.eq('Widget 1')
     expect(item.price).to.eq(11.22)
     expect(item.product_id).to.eq('1')
     expect(item.product_variant_id).to.eq('1')
-    expect(item.product_url).to.eq('http://main.magento.localhost:3006/widget-1.html')
+    expect(item.product_url).to.eq(`${getCurrentFrontendDomain()}/widget-1.html`)
     expect(item.quantity).to.eq(1)
     expect(item.sku).to.eq('widg-1')
     expect(item.taxes).to.eq(0)
@@ -358,12 +377,12 @@ Then('A configurable order event should be sent to Drip', function() {
     const item = body.items[0]
     expect(item.categories).to.be.empty
     expect(item.discounts).to.eq(0)
-    expect(item.image_url).to.eq('http://main.magento.localhost:3006/pub/media/catalog/product/')
+    expect(item.image_url).to.eq(`${getCurrentFrontendDomain()}/pub/media/catalog/product/`)
     expect(item.name).to.eq('Widget 1')
     expect(item.price).to.eq(11.22)
     expect(item.product_id).to.eq('3')
     expect(item.product_variant_id).to.eq('1')
-    expect(item.product_url).to.eq('http://main.magento.localhost:3006/widget-1.html')
+    expect(item.product_url).to.eq(`${getCurrentFrontendDomain()}/widget-1.html`)
     expect(item.quantity).to.eq(1)
     expect(item.sku).to.eq('widg-1-xl')
     expect(item.taxes).to.eq(0)
@@ -391,12 +410,12 @@ Then('A grouped order event should be sent to Drip', function() {
     const item1 = body.items[0]
     expect(item1.categories).to.be.empty
     expect(item1.discounts).to.eq(0)
-    expect(item1.image_url).to.eq('http://main.magento.localhost:3006/pub/media/catalog/product/')
+    expect(item1.image_url).to.eq(`${getCurrentFrontendDomain()}/pub/media/catalog/product/`)
     expect(item1.name).to.eq('Widget 1 Sub 1')
     expect(item1.price).to.eq(11.22)
     expect(item1.product_id).to.eq('2')
     expect(item1.product_variant_id).to.eq('2')
-    expect(item1.product_url).to.eq('http://main.magento.localhost:3006/widget-1-sub-1.html')
+    expect(item1.product_url).to.eq(`${getCurrentFrontendDomain()}/widget-1-sub-1.html`)
     expect(item1.quantity).to.eq(1)
     expect(item1.sku).to.eq('widg-1-sub1')
     expect(item1.taxes).to.eq(0)
@@ -405,12 +424,12 @@ Then('A grouped order event should be sent to Drip', function() {
     const item2 = body.items[1]
     expect(item2.categories).to.be.empty
     expect(item2.discounts).to.eq(0)
-    expect(item2.image_url).to.eq('http://main.magento.localhost:3006/pub/media/catalog/product/')
+    expect(item2.image_url).to.eq(`${getCurrentFrontendDomain()}/pub/media/catalog/product/`)
     expect(item2.name).to.eq('Widget 1 Sub 2')
     expect(item2.price).to.eq(11.22)
     expect(item2.product_id).to.eq('3')
     expect(item2.product_variant_id).to.eq('3')
-    expect(item2.product_url).to.eq('http://main.magento.localhost:3006/widget-1-sub-2.html')
+    expect(item2.product_url).to.eq(`${getCurrentFrontendDomain()}/widget-1-sub-2.html`)
     expect(item2.quantity).to.eq(1)
     expect(item2.sku).to.eq('widg-1-sub2')
     expect(item2.taxes).to.eq(0)
@@ -438,12 +457,12 @@ Then('A bundle order event should be sent to Drip', function() {
     const item = body.items[0]
     expect(item.categories).to.be.empty
     expect(item.discounts).to.eq(0)
-    expect(item.image_url).to.eq('http://main.magento.localhost:3006/pub/media/catalog/product/')
+    expect(item.image_url).to.eq(`${getCurrentFrontendDomain()}/pub/media/catalog/product/`)
     expect(item.name).to.eq('Widget 1')
     expect(item.price).to.eq(22.44)
     expect(item.product_id).to.eq('3')
     expect(item.product_variant_id).to.eq('3')
-    expect(item.product_url).to.eq('http://main.magento.localhost:3006/widget-1.html')
+    expect(item.product_url).to.eq(`${getCurrentFrontendDomain()}/widget-1.html`)
     expect(item.quantity).to.eq(1)
     expect(item.sku).to.eq('widg-1')
     expect(item.taxes).to.eq(0)

--- a/devtools_m2/cypress/integration/CustomerSubscriptionInteractions.feature
+++ b/devtools_m2/cypress/integration/CustomerSubscriptionInteractions.feature
@@ -4,6 +4,7 @@ Feature: Customer Subscription Interactions
 
   Scenario: A customer creates a subscribed account and then unsubscribes
     Given I am logged into the admin interface
+      And I have set up a multi-store configuration
       And I have configured Drip to be enabled for 'main'
     When I open the 'main' homepage
       And I create a 'subscribed' account
@@ -11,12 +12,32 @@ Feature: Customer Subscription Interactions
     When I 'unsubscribe' from the general newsletter
     Then A 'unsubscribed' event should be sent to Drip
 
-  @focus
   Scenario: A customer creates an unsubscribed account and then subscribes
     Given I am logged into the admin interface
+      And I have set up a multi-store configuration
       And I have configured Drip to be enabled for 'main'
     When I open the 'main' homepage
       And I create a 'unsubscribed' account
     Then A new 'unsubscribed' subscriber event should be sent to Drip
     When I 'subscribe' from the general newsletter
     Then A 'subscribed' event should be sent to Drip
+
+  Scenario: A customer creates a subscribed account and then unsubscribes when not configured for Drip
+    Given I am logged into the admin interface
+      And I have set up a multi-store configuration
+      And I have configured Drip to be enabled for 'main'
+    When I open the 'site1' homepage
+      And I create a 'subscribed' account
+    Then No web requests are sent
+    When I 'unsubscribe' from the general newsletter
+    Then No web requests are sent
+
+  Scenario: A customer creates an unsubscribed account and then subscribes when not configured for Drip
+    Given I am logged into the admin interface
+      And I have set up a multi-store configuration
+      And I have configured Drip to be enabled for 'main'
+    When I open the 'site1' homepage
+      And I create a 'unsubscribed' account
+    Then No web requests are sent
+    When I 'subscribe' from the general newsletter
+    Then No web requests are sent

--- a/devtools_m2/cypress/integration/CustomerSubscriptionInteractions/steps.js
+++ b/devtools_m2/cypress/integration/CustomerSubscriptionInteractions/steps.js
@@ -1,5 +1,6 @@
 import { Given, When, Then } from "cypress-cucumber-preprocessor/steps"
 import { mockServerClient } from "mockserver-client"
+import { getCurrentFrontendDomain } from "../../lib/frontend_context"
 
 const Mockclient = mockServerClient("localhost", 1080);
 
@@ -21,14 +22,9 @@ When('I create a {string} account', function(state) {
 Then('A new {string} subscriber event should be sent to Drip', function(state) {
   cy.log('Validating that the subscriber call has everything we need')
 
-  cy.wrap(Mockclient.retrieveRecordedRequests()).then(function(req){
-    console.log(req)
-  })
-
   cy.wrap(Mockclient.retrieveRecordedRequests({
     'path': '/v2/123456/subscribers'
   })).then(function(recordedRequests) {
-    console.log(recordedRequests)
     expect(recordedRequests).to.have.lengthOf(1)
     const body = JSON.parse(recordedRequests[0].body.string)
     expect(body.subscribers).to.have.lengthOf(1)
@@ -82,7 +78,7 @@ When('I {string} from the general newsletter', function(state) {
   cy.log('Resetting mocks')
   cy.wrap(Mockclient.reset())
 
-  cy.visit('/newsletter/manage/')
+  cy.visit(`${getCurrentFrontendDomain()}/newsletter/manage/`)
 
   if (state === 'unsubscribe') {
     cy.get('input[name="is_subscribed"]').uncheck()

--- a/devtools_m2/cypress/integration/common/admin.js
+++ b/devtools_m2/cypress/integration/common/admin.js
@@ -1,4 +1,5 @@
 import { Given, When, Then } from "cypress-cucumber-preprocessor/steps"
+import { mapFrontendWebsiteId } from "../../lib/frontend_context"
 
 Given('I am logged into the admin interface', function() {
   cy.visit(`http://main.magento.localhost:3006/admin_123`)
@@ -92,12 +93,15 @@ Given('I have configured a widget', function() {
 })
 
 // Simple Product
-Given('I have configured a simple widget', function() {
+Given('I have configured a simple widget for {string}', function(site) {
   cy.createProduct({
     "sku": "widg-1",
     "name": "Widget 1",
     "description": "This is really a widget. There are many like it, but this one is mine.",
     "shortDescription": "This is really a widget.",
+    // This is to set the context for the product save, so that rewrites and such get generated correctly.
+    "storeId": mapFrontendWebsiteId(site), // TODO: Fix to use the right store ID.
+    "websiteIds": [mapFrontendWebsiteId(site)]
   })
 })
 

--- a/devtools_m2/cypress/integration/common/common_mocking.js
+++ b/devtools_m2/cypress/integration/common/common_mocking.js
@@ -1,0 +1,11 @@
+import { Given, When, Then } from "cypress-cucumber-preprocessor/steps"
+import { mockServerClient } from "mockserver-client"
+
+const Mockclient = mockServerClient("localhost", 1080);
+
+Then('No web requests are sent', function() {
+  cy.log('Validating that we got nothing. Absolutely nothing.')
+  cy.wrap(Mockclient.retrieveRecordedRequests({})).then(function(recordedRequests) {
+    expect(recordedRequests).to.have.lengthOf(0)
+  })
+})

--- a/devtools_m2/cypress/integration/common/multi_store.js
+++ b/devtools_m2/cypress/integration/common/multi_store.js
@@ -1,5 +1,7 @@
 import { Given, When, Then } from "cypress-cucumber-preprocessor/steps"
+import { setCurrentFrontendSite, getCurrentFrontendDomain } from "../../lib/frontend_context"
 
 When('I open the {string} homepage', function(site) {
-  cy.visit(`http://${site}.magento.localhost:3006/`)
+  setCurrentFrontendSite(site)
+  cy.visit(getCurrentFrontendDomain())
 })

--- a/devtools_m2/cypress/lib/frontend_context.js
+++ b/devtools_m2/cypress/lib/frontend_context.js
@@ -1,0 +1,35 @@
+var currentSite = null
+
+function setCurrentFrontendSite(site) {
+  currentSite = site
+}
+
+function getCurrentFrontendDomain() {
+  return `http://${currentSite}.magento.localhost:3006`
+}
+
+function getCurrentFrontendSite() {
+  return currentSite
+}
+
+function getCurrentFrontendWebsiteId() {
+  return mapFrontendWebsiteId(currentSite)
+}
+
+function mapFrontendWebsiteId(site) {
+  let websiteId = 1
+  switch (site) {
+    case 'main':
+      websiteId = 1
+      break
+    case 'site1':
+      websiteId = 2
+      break
+    default:
+      throw `Unexpected site name ${site}`
+  }
+
+  return websiteId
+}
+
+export { setCurrentFrontendSite, getCurrentFrontendSite, getCurrentFrontendDomain, getCurrentFrontendWebsiteId, mapFrontendWebsiteId }

--- a/devtools_m2/cypress/support/docker_helpers.js
+++ b/devtools_m2/cypress/support/docker_helpers.js
@@ -1,3 +1,8 @@
+Cypress.Commands.add("flushCaches", () => {
+  cy.log('flushing Magento caches')
+  cy.exec('DRIP_COMPOSE_ENV=test ./flush_caches.sh')
+})
+
 beforeEach(function() {
   cy.log('resetting docker for test')
   cy.exec('DRIP_COMPOSE_ENV=test ./reset.sh')

--- a/devtools_m2/flush_caches.sh
+++ b/devtools_m2/flush_caches.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+./docker_compose.sh exec -T -u www-data web /bin/bash -c "cd /var/www/html/magento/ && ./bin/magento cache:clean && ./bin/magento cache:flush"
+./docker_compose.sh exec -T -u www-data web /bin/bash -c "cd /var/www/html/magento/ && ./bin/magento cache:clean && ./bin/magento indexer:reindex"

--- a/devtools_m2/php_utils/Creators/SimpleProductCreator.php
+++ b/devtools_m2/php_utils/Creators/SimpleProductCreator.php
@@ -10,18 +10,30 @@ class SimpleProductCreator
     /** @var \Magento\Catalog\Api\ProductRepositoryInterface **/
     protected $productRepository;
 
+    /** @var \Magento\Store\Model\StoreManagerInterface **/
+    protected $storeManager;
+
     public function __construct(
         \Magento\Catalog\Model\ProductFactory $catalogProductFactory,
         \Magento\Catalog\Api\ProductRepositoryInterface $productRepository,
+        \Magento\Store\Model\StoreManagerInterface $storeManager,
         $productData
     ) {
         $this->catalogProductFactory = $catalogProductFactory;
         $this->productRepository = $productRepository;
+        $this->storeManager = $storeManager;
         $this->productData = $productData;
     }
 
     public function create()
     {
+        // Indexing properly depends on the store ID being set in the context.
+        // Otherwise, the rewrites get created for the wrong store view.
+        if (\array_key_exists('storeId', $this->productData)) {
+            $store = $this->storeManager->getStore($this->productData['storeId']);
+            $this->storeManager->setCurrentStore($store->getCode());
+        }
+
         $this->productRepository->save($this->build());
     }
 

--- a/devtools_m2/reset.sh
+++ b/devtools_m2/reset.sh
@@ -3,4 +3,4 @@ set -e
 
 ./docker_compose.sh exec -T -e MYSQL_PWD=magento db mysql -u magento magento -e "DROP DATABASE magento; CREATE DATABASE magento"
 ./docker_compose.sh exec -T -e MYSQL_PWD=magento db mysql -u magento magento < db_data/dump.sql
-./docker_compose.sh exec -T -u www-data web /bin/bash -c "cd /var/www/html/magento/ && ./bin/magento cache:clean && ./bin/magento cache:flush"
+./flush_caches.sh


### PR DESCRIPTION
Port of https://github.com/DripEmail/magento-m1-extension/pull/17 to M2.

One thing to note is that this is purely test code. The underlying feature was fixed in a prior release.