### PR TITLE
Memory limit context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## NEXT
 
+*  Properly support multi-site. What makes this tricky is that customers are associated with websites, whereas orders are associated with store views. When an order event occurs, the order's store view is interrogated to determine which Drip configuration should be utilized. When a frontend customer event occurs, the currently used store view is utilized; however for an admin customer event, the first store view for that website is used. This means that trying to configure Drip at a store view level when there is more than one store view per website may result in unexpected behavior.
 * Set occurred_at on cart events.
 * Use parent image and url when child products are not individually visible
+* Only allow setting the memory limit override globally
 
 ## 1.7.6
 

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -44,7 +44,7 @@
                     <label>Batch Delay</label>
                     <comment>Delay in seconds between batch api calls (not recommended to have it lower than 72)</comment>
                 </field>
-                <field id="memory_limit" translate="label comment" type="text" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="memory_limit" translate="label comment" type="text" sortOrder="60" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Memory Limit</label>
                     <comment>Memory Limit in Mb</comment>
                 </field>


### PR DESCRIPTION
Only allow the memory limit to be set globally, since we're only using it globally.