### PR TITLE
Use published image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ matrix:
       language: node_js
       node_js:
         - '10'
+      env:
+        secure: KLIVg65GQEnm6/VN+EL3DRviLCJ1tHBuncMu6Hj5+2+mxLoTgB04fGkPIA/DrhTQIyua0Pfawj8BlAgCXjjzqdLiDhqLu1EYu2Dx/6WnqRh6Xyq1NphkYZPzOI7ogztSKbSl2POEGdjmLCOlbYl11SQUbUfbGvD+xhBGTI/S/WGJ/OnqRmAht7v+RXmWL2fUb5UwsbhcZ1dsHmpHaPF0HR68Jl9cPQyIvk8DpDjOl17M3Z8bGy6aNpW4qOgi99jxWAIM81Dsw5nAeaUuVSpvRSakE2y2/5vfyYuKhAlYt2KQrR8vODdbOydCwGbYQLLqNrBXW7hkuSZ1IZjtMBX8dRk2tNFsarVtVjM/DpH9KVEQasVtddLiVeD9TJ3FFtwz43VMdfQPagWWMahKVFWivh8pGGHQFM6VpJ8KalFdpCQbQtBsblxh9R+7pfzCHl3aG2iKj0L3i9yaYjcANKdSkqNjY2ZuroFq7NKNkWw+u/Y/9W734AJxnYR5iphRAy7vV/zfDck/irjqNoyKAn1QWR157lHk610KcAXBUJYruXHre5LdvqLDXhkgTZkXyNpaBiV9G0kemBvHfjDSwuHdvqBju1Qt7oFxxHjwVJz44zTMJjOnlcrHHoNogWG/NXoC1LNhRCQyicXllQUVvtWuRe0ZNjZp3gGESOZAbsxmkKU=
       addons:
         chrome: stable
         hosts:
@@ -39,8 +41,9 @@ matrix:
         directories:
           # we also need to cache folder with Cypress binary
           - ~/.cache
+      before_install:
+        - pip install --user awscli
       install:
         - cd $TRAVIS_BUILD_DIR/devtools_m2/ && npm ci
       script:
         - cd $TRAVIS_BUILD_DIR/devtools_m2/ && ./tests.sh
-

--- a/devtools_m2/docker-compose.base.yml
+++ b/devtools_m2/docker-compose.base.yml
@@ -1,10 +1,7 @@
 version: '3.7'
 services:
   web:
-    build:
-      context: .
-      args:
-          - CONTINUOUS_INTEGRATION
+    image: 648846177135.dkr.ecr.us-east-1.amazonaws.com/eci/magento-m2-extension:2.3.2
     ports:
     - 3006:80
     links:

--- a/devtools_m2/docker_build.sh
+++ b/devtools_m2/docker_build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+host=648846177135.dkr.ecr.us-east-1.amazonaws.com
+repo=eci
+name=magento-m2-extension
+tag=2.3.2
+
+image=$host/$repo/$name:$tag
+
+docker build --build-arg CONTINUOUS_INTEGRATION="true" -t $image .

--- a/devtools_m2/setup.sh
+++ b/devtools_m2/setup.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+eval $(aws ecr get-login --no-include-email --registry-ids 648846177135 --region us-east-1)
+
 # Spin up a new instance of Magento
 # Add --build when you need to rebuild the Dockerfile.
 ./docker_compose.sh up -d


### PR DESCRIPTION
Hosting docker image on ECR.


- [x] Publish base image to ECR: `648846177135.dkr.ecr.us-east-1.amazonaws.com/eci/magento-m2-extension:2.3.2`
- [x] Update `docker-compose.base.yml` image
- [x] Install or confirm `aws` cli tool is available in root travis image.
- [x] Add encrypted aws env vars to `.travis.yml` (`--org` here is important):
    - [x] `travis encrypt --add env --org --override AWS_ACCESS_KEY_ID=XXXXX AWS_SECRET_ACCESS_KEY=XXXXX`
- [x] Add ECR docker login: `eval $(aws ecr get-login --region XXXXXX --registry 648846177135)`