### PR TITLE
magento2 under docker "enhancements"

### DIFF
--- a/devtools_m2/cypress.json
+++ b/devtools_m2/cypress.json
@@ -3,8 +3,8 @@
   "ignoreTestFiles": "*.js",
   "baseUrl": "http://main.magento.localhost:3006",
 
-  "defaultCommandTimeout": 10000,
+  "defaultCommandTimeout": 15000,
   "pageLoadTimeout": 100000,
-  "requestTimeout": 10000,
+  "requestTimeout": 15000,
   "responseTimeout": 10000
 }

--- a/devtools_m2/setup.sh
+++ b/devtools_m2/setup.sh
@@ -39,8 +39,7 @@ MAGE_MODE=developer ./bin/magento setup:install \
 ./bin/magento config:set dev/css/merge_css_files 1 && \
 ./bin/magento config:set dev/css/minify_files 1 && \
 ./bin/magento setup:static-content:deploy -f && \
-./bin/magento deploy:mode:set production && \
-./bin/magento cron:run
+./bin/magento deploy:mode:set production
 SCRIPT
 )
 

--- a/devtools_m2/setup.sh
+++ b/devtools_m2/setup.sh
@@ -31,8 +31,16 @@ MAGE_MODE=developer ./bin/magento setup:install \
 --admin-lastname=LAST_NAME && \
 ./bin/magento setup:config:set --backend-frontname='admin_123' && \
 ./bin/magento config:set admin/security/admin_account_sharing 1 && \
+./bin/magento config:set catalog/frontend/flat_catalog_product 1 && \
 ./bin/magento config:set admin/security/use_form_key 0 && \
-./bin/magento deploy:mode:set developer
+./bin/magento config:set dev/js/merge_files 1 && \
+./bin/magento config:set dev/js/enable_js_bundling 1 && \
+./bin/magento config:set dev/js/minify_files 1 && \
+./bin/magento config:set dev/css/merge_css_files 1 && \
+./bin/magento config:set dev/css/minify_files 1 && \
+./bin/magento setup:static-content:deploy -f && \
+./bin/magento deploy:mode:set production && \
+./bin/magento cron:run
 SCRIPT
 )
 


### PR DESCRIPTION
ports longer cypress timeouts from m1.  These ended up clearing up all the spurious timeouts from cy.contains() and such.

Magento2, when in developer mode, has a considerable amount of filesystem i/o, which is particularly slow when running inside a Docker container on MacOS.  To boost performance, the system is now put into production mode, and pre-compiles "static" content [instead of having it done at request time].

Also some generic tuning is done by following recommended settings similar to here:
https://www.mageplaza.com/blog/magento-2-performance-optimization/