### PR TITLE
migrating m1 behavior

### DIFF
--- a/Model/Transformer/Order.php
+++ b/Model/Transformer/Order.php
@@ -81,6 +81,7 @@ class Order
             'grand_total' => $this->connectHelper->priceAsCents($this->order->getGrandTotal()) / 100,
             'total_discounts' => $this->connectHelper->priceAsCents($this->order->getDiscountAmount()) / 100,
             'total_taxes' => $this->connectHelper->priceAsCents($this->order->getTaxAmount()) / 100,
+            'total_shipping' => 0,
             'currency' => (string) $this->order->getOrderCurrencyCode(),
             'occurred_at' => (string) $this->connectHelper->formatDate($this->order->getUpdatedAt()),
             'items' => $this->getOrderItemsData(),
@@ -226,6 +227,10 @@ class Order
      */
     protected function getOrderAddressData($addressId)
     {
+        if($addressId === null) {
+            return;
+        }
+
         $address = $this->salesOrderAddressFactory->create()->load($addressId);
         return $this->buildOrderAddressDataStructure($address);
     }

--- a/Model/Transformer/Order.php
+++ b/Model/Transformer/Order.php
@@ -81,7 +81,7 @@ class Order
             'grand_total' => $this->connectHelper->priceAsCents($this->order->getGrandTotal()) / 100,
             'total_discounts' => $this->connectHelper->priceAsCents($this->order->getDiscountAmount()) / 100,
             'total_taxes' => $this->connectHelper->priceAsCents($this->order->getTaxAmount()) / 100,
-            'total_shipping' => 0,
+            'total_shipping' => $this->connectHelper->priceAsCents($this->order->getShippingAmount()) / 100,
             'currency' => (string) $this->order->getOrderCurrencyCode(),
             'occurred_at' => (string) $this->connectHelper->formatDate($this->order->getUpdatedAt()),
             'items' => $this->getOrderItemsData(),
@@ -90,9 +90,11 @@ class Order
             'magento_source' => (string) $this->connectHelper->getArea(),
         ];
 
+        // The following differs from M1 based on Magento's documenation that states that M2 will
+        // will only present shipping information to the end user if an order contains non-virtual
+        // products.
         if($this->hasPhysicalProduct()) {
             $data['shipping_address'] = $this->getOrderShippingData();
-            $data['total_shipping'] = $this->connectHelper->priceAsCents($this->order->getShippingAmount()) / 100;
         }
 
         return $data;

--- a/Model/Transformer/Order.php
+++ b/Model/Transformer/Order.php
@@ -90,7 +90,7 @@ class Order
             'magento_source' => (string) $this->connectHelper->getArea(),
         ];
 
-        // The following differs from M1 based on Magento's documenation that states that M2 will
+        // The following differs from M1 based on Magento's documentation that states that M2 will
         // will only present shipping information to the end user if an order contains non-virtual
         // products.
         if($this->hasPhysicalProduct()) {

--- a/devtools_m2/cypress/integration/AdminOrderInteractions/steps.js
+++ b/devtools_m2/cypress/integration/AdminOrderInteractions/steps.js
@@ -40,7 +40,7 @@ Then('an order event is sent to Drip for the {string} widget', function(widgetTy
 
     if(isVirtualProduct(widgetType)) {
       expect(Object.keys(body)).to.not.contain('shipping_address')
-      expect(Object.keys(body)).to.not.contain('total_shipping')
+      expect(body.total_shipping).to.eq(0)
     } else {
       expect(body.total_shipping).to.eq(5)
       expect(body.shipping_address.address_1).to.eq('123 Main St.')

--- a/devtools_m2/cypress/integration/CustomerCartInteractions/steps.js
+++ b/devtools_m2/cypress/integration/CustomerCartInteractions/steps.js
@@ -424,8 +424,8 @@ Then('A virtual order event should be sent to Drip', function() {
     expect(body.initial_status).to.eq('unsubscribed')
     expect(body.items_count).to.eq(1)
     expect(body.items).to.have.lengthOf(1)
+    expect(body.total_shipping).to.eq(0)
 
-    expect(Object.keys(body)).to.not.contain('total_shipping')
     expect(Object.keys(body)).to.not.contain('shipping_address')
 
     basicOrderBodyAssertions(body, false)


### PR DESCRIPTION
addresses [ECI-392](https://dripcom.atlassian.net/browse/ECI-392)

This is effectively a no-op PR, but it does bring the M1 and M2 code-bases more in line.  There's a few chosen differences based on documentation wording from Adobe about M2:
"Shipping Options do not appear during checkout unless there is a tangible product in the cart."