### PR TITLE
Fetch email for identification with ajax

### DIFF
--- a/Model/Plugin/CustomerData.php
+++ b/Model/Plugin/CustomerData.php
@@ -19,6 +19,7 @@ class CustomerData
     {
         if ($this->currentCustomer->getCustomerId()) {
             $customer = $this->currentCustomer->getCustomer();
+            // Add email to the customerData.get("customer") hash. This'll allow us to fetch it uncached by page caching.
             $result['email'] = $customer->getEmail();
         }
 

--- a/Model/Plugin/CustomerData.php
+++ b/Model/Plugin/CustomerData.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drip\Connect\Model\Plugin;
+
+class CustomerData
+{
+    /**
+     * @var CurrentCustomer
+     */
+    private $currentCustomer;
+
+    public function __construct(
+        \Magento\Customer\Helper\Session\CurrentCustomer $currentCustomer
+    ) {
+        $this->currentCustomer = $currentCustomer;
+    }
+
+    public function afterGetSectionData(\Magento\Customer\CustomerData\Customer $subject, $result)
+    {
+        if ($this->currentCustomer->getCustomerId()) {
+            $customer = $this->currentCustomer->getCustomer();
+            $result['email'] = $customer->getEmail();
+        }
+
+        return $result;
+    }
+}

--- a/devtools_m2/cypress/integration/CustomerIdentity/steps.js
+++ b/devtools_m2/cypress/integration/CustomerIdentity/steps.js
@@ -17,7 +17,7 @@ When('I create an account', function() {
 
 Then('an identify call is made to Drip', function() {
   cy.log('Validating that an identify call was made')
-  cy.get('script').then((scriptTags) => {
+  cy.get('script').should((scriptTags) => {
     const identifyTags = scriptTags.toArray().filter(function(tag) {
       return tag.src.match(/https:\/\/api.getdrip.com\/client\/identify\?time_zone=[a-zA-Z0-9_%]+&visitor_uuid=\w+&email=testuser%40example.com&drip_account_id=123456&callback=/)
     })

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -13,4 +13,7 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\Customer\CustomerData\Customer">
+        <plugin name="additional_section_data" type="Drip\Connect\Model\Plugin\CustomerData" />
+    </type>
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -13,6 +13,7 @@
             </argument>
         </arguments>
     </type>
+    <!-- Inject additional data into the customerData.get("customer") hash for private fetching of email.  -->
     <type name="Magento\Customer\CustomerData\Customer">
         <plugin name="additional_section_data" type="Drip\Connect\Model\Plugin\CustomerData" />
     </type>

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -4,6 +4,11 @@ var config = {
             'Magento_Checkout/js/action/set-shipping-information': {
                 'Drip_Connect/js/order/set-shipping-information-mixin': true
             }
+        },
+        map: {
+            '*': {
+                identification: 'Drip_Connect/js/identification',
+            }
         }
     }
 };

--- a/view/frontend/templates/drip/footer_js.phtml
+++ b/view/frontend/templates/drip/footer_js.phtml
@@ -15,6 +15,13 @@
                 s.parentNode.insertBefore(dc, s);
             })();
         </script>
+        <script type="text/x-magento-init">
+        {
+            "*": {
+                "Drip_Connect/js/identification": {}
+            }
+        }
+        </script>
         <!-- end Drip -->
     <?php else : ?>
         <!-- Skipping Drip JS inclusion due to lack of account id -->

--- a/view/frontend/templates/drip/footer_js.phtml
+++ b/view/frontend/templates/drip/footer_js.phtml
@@ -15,6 +15,7 @@
                 s.parentNode.insertBefore(dc, s);
             })();
         </script>
+        <!-- Inject dynamically in order to bypass page caching... -->
         <script type="text/x-magento-init">
         {
             "*": {

--- a/view/frontend/templates/drip/footer_js.phtml
+++ b/view/frontend/templates/drip/footer_js.phtml
@@ -16,16 +16,6 @@
             })();
         </script>
         <!-- end Drip -->
-
-        <?php if ($block->isCustomerLoggedIn()) : ?>
-            <!-- identify Drip customer -->
-            <script type="text/javascript">
-            _dcq.push(["identify", {
-                email: "<?= $block->getCustomerEmail()?>"
-            }]);
-            </script>
-            <!-- end identify -->
-        <?php endif; ?>
     <?php else : ?>
         <!-- Skipping Drip JS inclusion due to lack of account id -->
     <?php endif; ?>

--- a/view/frontend/web/js/identification.js
+++ b/view/frontend/web/js/identification.js
@@ -1,0 +1,27 @@
+define([
+  "Magento_Customer/js/customer-data"
+], function(customerData) {
+  "use strict";
+
+  function identifyCustomer(email) {
+    if (email) {
+      window._dcq.push(["identify", {
+        email: email
+      }]);
+    }
+  }
+
+  return function (config, element) {
+    var email = customerData.get("customer")().email;
+
+    // This data is cached in localstorage. It may have changed, so refetch if we don't have it.
+    if (typeof (email) === "undefined") {
+      customerData.reload("customer").then(function() {
+        email = customerData.get("customer")().email;
+        identifyCustomer(email);
+      });
+    } else {
+      identifyCustomer(email);
+    }
+  };
+});


### PR DESCRIPTION
If a customer uses a page caching system like Varnish, it's possible for the identification to be cached depending on how they have this set up. This could possibly leak emails across visitor sessions.

Instead of injecting the email into the template, fetch it from the server with an uncached ajax call.