### PR TITLE
REST endpoint to return account id

### DIFF
--- a/Api/Settings.php
+++ b/Api/Settings.php
@@ -1,0 +1,33 @@
+<?php
+namespace Drip\Connect\Api;
+use Drip\Connect\Api\SettingsInterface;
+
+class Settings implements SettingsInterface
+{
+		/** @var \Drip\Connect\Model\ConfigurationFactory */
+		protected $configFactory;
+
+		/** @var \Magento\Store\Model\StoreManagerInterface */
+		protected $storeManager;
+
+		public function __construct(
+				\Drip\Connect\Model\ConfigurationFactory $configFactory,
+        \Magento\Store\Model\StoreManagerInterface $storeManager
+		) {
+				$this->configFactory = $configFactory;
+        $this->storeManager = $storeManager;
+		}
+
+		/**
+		 * Retrieves Drip account_id
+		 * @param string $websiteId
+		 * @return string
+		 */
+    public function getAccountId($websiteId) {
+				$storeIds = $this->storeManager->getWebsite($websiteId)->getStoreIds();
+				reset($storeIds);
+				$storeId = current($storeIds);
+				$config = $this->configFactory->create($storeId);
+				return json_encode(['account_id' => $config->getAccountId()]);
+    }
+}

--- a/Api/SettingsInterface.php
+++ b/Api/SettingsInterface.php
@@ -1,0 +1,10 @@
+<?php
+namespace Drip\Connect\Api;
+interface SettingsInterface {
+		/**
+		 * GET for Settings api
+		 * @param string $websiteId
+		 * @return string
+		 */
+    public function getAccountId($websiteId);
+}

--- a/acl.xml
+++ b/acl.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
+    <acl>
+        <resources>
+            <resource id="Magento_Backend::admin">
+                <resource id="Drip::account_id" title="account_id" translate="title" sortOrder="110" />
+            </resource>
+        </resources>
+    </acl>
+</config>

--- a/devtools_m2/cypress/integration/RestApi.feature
+++ b/devtools_m2/cypress/integration/RestApi.feature
@@ -2,7 +2,12 @@ Feature: REST API Interactions
 
   I want to make plugin settings available via the REST API
 
-  Scenario: Request for account_id
+  Scenario: Authorized request for account_id
     Given I am logged into the admin interface
       And I have configured Drip to be enabled for 'main'
-    Then a REST API request gives the correct response
+    Then an authorized REST API request gives the correct response
+
+  Scenario: Unauthorized equest for account_id
+    Given I am logged into the admin interface
+      And I have configured Drip to be enabled for 'main'
+    Then an unauthorized REST API request gives the correct response

--- a/devtools_m2/cypress/integration/RestApi.feature
+++ b/devtools_m2/cypress/integration/RestApi.feature
@@ -1,0 +1,8 @@
+Feature: REST API Interactions
+
+  I want to make plugin settings available via the REST API
+
+  Scenario: Request for account_id
+    Given I am logged into the admin interface
+      And I have configured Drip to be enabled for 'main'
+    Then a REST API request gives the correct response

--- a/devtools_m2/cypress/integration/RestApi/steps.js
+++ b/devtools_m2/cypress/integration/RestApi/steps.js
@@ -3,9 +3,26 @@ import { mockServerClient } from "mockserver-client"
 
 const Mockclient = mockServerClient("localhost", 1080);
 
-Then('a REST API request gives the correct response', function(site) {
-  cy.request("http://main.magento.localhost:3006/rest/V1/drip/account_id?websiteId=1").then((response) => {
-    expect(response.status).to.eq(200)
-    expect(JSON.parse(response.body)["account_id"]).to.eq('123456')
+Then('an authorized REST API request gives the correct response', function(site) {
+  cy.request({
+    url: "http://main.magento.localhost:3006/rest/V1/integration/admin/token",
+    method: "POST",
+    body: {"username":"admin", "password":"abc1234567890"}
+  }).then((token_response) => {
+    cy.request({
+      url: "http://main.magento.localhost:3006/rest/V1/drip/account_id?websiteId=1",
+      auth: {
+        bearer: token_response.body
+      }
+    }).then((response) => {
+      expect(response.status).to.eq(200)
+      expect(JSON.parse(response.body)["account_id"]).to.eq('123456')
+    })
+  })
+})
+
+Then('an unauthorized REST API request gives the correct response', function(site) {
+  cy.request({ url: "http://main.magento.localhost:3006/rest/V1/drip/account_id?websiteId=1", failOnStatusCode: false }).then((response) => {
+    expect(response.status).to.eq(401)
   })
 })

--- a/devtools_m2/cypress/integration/RestApi/steps.js
+++ b/devtools_m2/cypress/integration/RestApi/steps.js
@@ -1,0 +1,11 @@
+import { Given, When, Then } from "cypress-cucumber-preprocessor/steps"
+import { mockServerClient } from "mockserver-client"
+
+const Mockclient = mockServerClient("localhost", 1080);
+
+Then('a REST API request gives the correct response', function(site) {
+  cy.request("http://main.magento.localhost:3006/rest/V1/drip/account_id?websiteId=1").then((response) => {
+    expect(response.status).to.eq(200)
+    expect(JSON.parse(response.body)["account_id"]).to.eq('123456')
+  })
+})

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -13,4 +13,6 @@
             </argument>
         </arguments>
     </type>
+    <preference for="Drip\Connect\Api\SettingsInterface"
+            type="Drip\Connect\Api\Settings" />
 </config>

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -3,7 +3,7 @@
     <route method="GET" url="/V1/drip/account_id">
         <service class="Drip\Connect\Api\SettingsInterface" method="getAccountId"/>
         <resources>
-            <resource ref="anonymous"/>
+            <resource ref="Drip::account_id"/>
         </resources>
     </route>
 </routes>

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Webapi:etc/webapi.xsd">
+    <route method="GET" url="/V1/drip/account_id">
+        <service class="Drip\Connect\Api\SettingsInterface" method="getAccountId"/>
+        <resources>
+            <resource ref="anonymous"/>
+        </resources>
+    </route>
+</routes>


### PR DESCRIPTION
Endpoint to return Drip account id, given a website id. Intended as a model for building other custom endpoints.