### PR TITLE
configuration uses website id

### DIFF
--- a/Model/Configuration.php
+++ b/Model/Configuration.php
@@ -26,9 +26,9 @@ class Configuration
     protected $storeManager;
 
     /**
-     * @var int The store's ID
+     * @var int The website's ID
      */
-    protected $storeId;
+    protected $websiteId;
 
     /**
      * @var string The config's scope
@@ -39,52 +39,35 @@ class Configuration
      * @param \Magento\Config\Model\ResourceModel\Config $resourceConfig
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
      * @param \Magento\Store\Model\StoreManagerInterface $storeManager,
-     * @param int $storeId The ID of the Store View (called `store` in the DB and code)
+     * @param int $websiteId The ID of the Website
      */
     public function __construct(
         \Magento\Config\Model\ResourceModel\Config $resourceConfig,
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
         \Magento\Store\Model\StoreManagerInterface $storeManager,
-        int $storeId
+        int $websiteId
     ) {
         $this->resourceConfig = $resourceConfig;
         $this->scopeConfig = $scopeConfig;
         $this->storeManager = $storeManager;
-        $this->storeId = $storeId;
+        $this->websiteId = $websiteId;
 
-        // M2 requires a more modern approach of not using 0 as the default ID,
-        // but rather relying on a scope type. This is great, but we don't need
-        // that complexity. Simplify...
-        if ((int) $storeId === \Magento\Store\Model\Store::DEFAULT_STORE_ID) {
-            $this->scope = \Magento\Framework\App\Config\ScopeConfigInterface::SCOPE_TYPE_DEFAULT;
-        } else {
-            $this->scope = \Magento\Store\Model\ScopeInterface::SCOPE_STORE;
-        }
+		$this->scope = \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITES;
     }
 
-    public function getStoreId()
-    {
-        return $this->storeId;
-    }
-
-    /**
-     * The website ID attached to the current store view.
-     *
-     * @return int
-     */
     public function getWebsiteId()
     {
-        return $this->storeManager->getStore($this->storeId)->getWebsiteId();
+        return $this->websiteId;
     }
 
     public function getWisUrl()
     {
-        return $this->getStoreConfig(self::WIS_URL_PATH);
+        return $this->getWebsiteConfig(self::WIS_URL_PATH);
     }
 
     public function getIntegrationToken()
     {
-        return $this->getStoreConfig(self::INTEGRATION_TOKEN);
+        return $this->getWebsiteConfig(self::INTEGRATION_TOKEN);
     }
 
     /**
@@ -92,28 +75,28 @@ class Configuration
      */
     public function isEnabled()
     {
-        return (bool) $this->getStoreConfig(self::MODULE_ENABLED_PATH);
+        return (bool) $this->getWebsiteConfig(self::MODULE_ENABLED_PATH);
     }
 
     public function getSalt()
     {
-        return $this->getStoreConfig(self::SALT_PATH);
+        return $this->getWebsiteConfig(self::SALT_PATH);
     }
 
     public function getLogSettings()
     {
-        return $this->getStoreConfig(self::LOG_SETTINGS_PATH);
+        return $this->getWebsiteConfig(self::LOG_SETTINGS_PATH);
     }
 
     /**
      * @param string $path
      */
-    protected function getStoreConfig($path)
+    protected function getWebsiteConfig($path)
     {
         return $this->scopeConfig->getValue(
             $path,
             $this->scope,
-            $this->storeId
+            $this->websiteId
         );
     }
 }

--- a/Model/Configuration.php
+++ b/Model/Configuration.php
@@ -62,12 +62,12 @@ class Configuration
 
     public function getWisUrl()
     {
-        return $this->getWebsiteConfig(self::WIS_URL_PATH);
+        return $this->getConfig(self::WIS_URL_PATH);
     }
 
     public function getIntegrationToken()
     {
-        return $this->getWebsiteConfig(self::INTEGRATION_TOKEN);
+        return $this->getConfig(self::INTEGRATION_TOKEN);
     }
 
     /**
@@ -75,23 +75,23 @@ class Configuration
      */
     public function isEnabled()
     {
-        return (bool) $this->getWebsiteConfig(self::MODULE_ENABLED_PATH);
+        return (bool) $this->getConfig(self::MODULE_ENABLED_PATH);
     }
 
     public function getSalt()
     {
-        return $this->getWebsiteConfig(self::SALT_PATH);
+        return $this->getConfig(self::SALT_PATH);
     }
 
     public function getLogSettings()
     {
-        return $this->getWebsiteConfig(self::LOG_SETTINGS_PATH);
+        return $this->getConfig(self::LOG_SETTINGS_PATH);
     }
 
     /**
      * @param string $path
      */
-    protected function getWebsiteConfig($path)
+    protected function getConfig($path)
     {
         return $this->scopeConfig->getValue(
             $path,

--- a/Model/ConfigurationFactory.php
+++ b/Model/ConfigurationFactory.php
@@ -38,16 +38,16 @@ class ConfigurationFactory
      * @param int $storeId
      * @return \Drip\Connect\Model\Configuration
      */
-	public function create(int $storeId)
+    public function create(int $storeId)
     {
-		$websiteId = $this->storeManager->getStore($storeId)->getWebsiteId();
-		return $this->createFromWebsiteId($websiteId);
-	}
+        $websiteId = $this->storeManager->getStore($storeId)->getWebsiteId();
+        return $this->createFromWebsiteId($websiteId);
+    }
 
-	public function createFromWebsiteId(int $websiteId)
-	{
-		return $this->objectManager->create(\Drip\Connect\Model\Configuration::class, ['websiteId' => $websiteId]);
-	}
+    public function createFromWebsiteId(int $websiteId)
+    {
+        return $this->objectManager->create(\Drip\Connect\Model\Configuration::class, ['websiteId' => $websiteId]);
+    }
 
     /**
      * Create a configuration model scoped to the current store based on the request param
@@ -68,10 +68,10 @@ class ConfigurationFactory
      *
      * @return \Drip\Connect\Model\Configuration
      */
-	 public function createForGlobalScope()
-	 {
-		$websiteId = $this->storeManager->getDefaultStoreView()->getWebsiteId();
-		return $this->createFromWebsiteId($websiteId);
+    public function createForGlobalScope()
+    {
+        $websiteId = $this->storeManager->getDefaultStoreView()->getWebsiteId();
+        return $this->createFromWebsiteId($websiteId);
     }
 
     /**

--- a/Model/ConfigurationFactory.php
+++ b/Model/ConfigurationFactory.php
@@ -40,8 +40,14 @@ class ConfigurationFactory
      */
     public function create(int $storeId)
     {
-        return $this->objectManager->create(\Drip\Connect\Model\Configuration::class, ['storeId' => $storeId]);
+        $websiteId = $this->storeManager->getStore($storeId)->getWebsiteId();
+		return $this->createFromWebsiteId($websiteId);
     }
+
+	public function createFromWebsiteId(int $websiteId)
+	{
+		return $this->objectManager->create(\Drip\Connect\Model\Configuration::class, ['websiteId' => $websiteId]);
+	}
 
     /**
      * Create a configuration model scoped to the current store based on the request param
@@ -64,7 +70,8 @@ class ConfigurationFactory
      */
     public function createForGlobalScope()
     {
-        return $this->create(\Magento\Store\Model\Store::DEFAULT_STORE_ID);
+		$websiteId = $this->storeManager->getDefaultStoreView()->getWebsiteId();
+        return $this->createFromWebsiteId($websiteId);
     }
 
     /**

--- a/Model/ConfigurationFactory.php
+++ b/Model/ConfigurationFactory.php
@@ -38,11 +38,11 @@ class ConfigurationFactory
      * @param int $storeId
      * @return \Drip\Connect\Model\Configuration
      */
-    public function create(int $storeId)
+	public function create(int $storeId)
     {
-        $websiteId = $this->storeManager->getStore($storeId)->getWebsiteId();
+		$websiteId = $this->storeManager->getStore($storeId)->getWebsiteId();
 		return $this->createFromWebsiteId($websiteId);
-    }
+	}
 
 	public function createFromWebsiteId(int $websiteId)
 	{
@@ -68,10 +68,10 @@ class ConfigurationFactory
      *
      * @return \Drip\Connect\Model\Configuration
      */
-    public function createForGlobalScope()
-    {
+	 public function createForGlobalScope()
+	 {
 		$websiteId = $this->storeManager->getDefaultStoreView()->getWebsiteId();
-        return $this->createFromWebsiteId($websiteId);
+		return $this->createFromWebsiteId($websiteId);
     }
 
     /**

--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -89,10 +89,6 @@ class UpgradeData implements \Magento\Framework\Setup\UpgradeDataInterface
             $this->updateCustomerDripAttribute();
         }
 
-        if (version_compare($context->getVersion(), '1.5.2') < 0) {
-            $this->changeTimeout();
-        }
-
         $setup->endSetup();
     }
 
@@ -115,13 +111,5 @@ class UpgradeData implements \Magento\Framework\Setup\UpgradeDataInterface
                 );
             $attribute->save();
         }
-    }
-
-    /**
-     * change api call timeout value
-     */
-    protected function changeTimeout()
-    {
-        $this->configFactory->createForGlobalScope()->setTimeout(30000);
     }
 }

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -8,7 +8,6 @@
             </module_settings>
             <api_settings>
                 <wis_url>https://woo.drip.sh</wis_url>
-                <timeout>30000</timeout>
             </api_settings>
         </dripconnect_general>
     </default>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -8,6 +8,7 @@
             </module_settings>
             <api_settings>
                 <wis_url>https://woo.drip.sh</wis_url>
+                <timeout>30000</timeout>
             </api_settings>
         </dripconnect_general>
     </default>


### PR DESCRIPTION
Updates `Configuration` and `ConfigurationFactory` to use a websiteId rather than a storeId, and to use website scope.

I also removed call to `setTimeout` that prompted me to add that function back in this one: https://github.com/DripEmail/magento-m2-extension/pull/65