### PR TITLE
Cease double encoding

### DIFF
--- a/Api/ResourceDetails.php
+++ b/Api/ResourceDetails.php
@@ -32,7 +32,7 @@ class ResourceDetails implements ResourceDetailsInterface
      */
     public function orderDetails($orderId) {
         $url = $this->orderViewInfo->getViewUrl($orderId);
-        return json_encode(['order_url' => $url]);
+        return ['order_url' => $url];
     }
 
     /**
@@ -44,6 +44,6 @@ class ResourceDetails implements ResourceDetailsInterface
         if (!empty($productImage)) {
             $productImage = $this->catalogProductMediaConfigFactory->create()->getMediaUrl($productImage);
         }
-        return json_encode(['product_url' => $product->getProductUrl(), 'image_url' => $productImage]);
+        return ['product_url' => $product->getProductUrl(), 'image_url' => $productImage];
     }
 }

--- a/Api/Settings.php
+++ b/Api/Settings.php
@@ -36,7 +36,7 @@ class Settings implements SettingsInterface
         $config = $this->configFactory->createFromWebsiteId($websiteId);
         $config->setAccountParam($accountParam);
         $config->setIntegrationToken($integrationToken);
-        return json_encode(['account_param' => $config->getAccountParam(), 'integration_token' => $config->getIntegrationToken()]);
+        return ['account_param' => $config->getAccountParam(), 'integration_token' => $config->getIntegrationToken()];
     }
 
     /**
@@ -45,11 +45,11 @@ class Settings implements SettingsInterface
     public function showStatus($websiteId = 0) {
         $website = $this->storeManager->getWebsite($websiteId);
         $config = $this->configFactory->createFromWebsiteId($websiteId);
-        return json_encode([
+        return [
             'account_param' => $config->getAccountParam(),
             'integration_token' => $config->getIntegrationToken(),
             'magento_version' => $this->productMetadata->getVersion(),
             'plugin_version' => $this->moduleResource->getDbVersion('Drip_Connect')
-        ]);
+        ];
     }
 }


### PR DESCRIPTION
It looks like whatever we return from an API endpoint gets JSON encoded.

Normally, the raw string response from an API looks like this:
```json
{"product_url":"https://magento2-dev2.demo.drip.io/fuzzy-cat-toy.html","image_url":"https://magento2-dev2.demo.drip.io/pub/media/catalog/product/5/8/580b57fbd9996e24bc43bb94.png"}
```

But it's double-encoding to look like:
```json
"{\"product_url\":\"https:\\/\\/magento2-dev2.demo.drip.io\\/fuzzy-cat-toy.html\",\"image_url\":\"https:\\/\\/magento2-dev2.demo.drip.io\\/pub\\/media\\/catalog\\/product\\/5\\/8\\/580b57fbd9996e24bc43bb94.png\"}"

```