### PR TITLE
fix class

### DIFF
--- a/Api/Settings.php
+++ b/Api/Settings.php
@@ -13,7 +13,7 @@ class Settings
     protected $moduleResource;
 
     /**
-    * @var \Drip\Connect\Api\ResponseFactory
+    * @var \Drip\Connect\Api\SettingsResponseFactory
     */
     protected $responseFactory;
 


### PR DESCRIPTION
I noticed that the class for a factory was incorrect in a variable declaration. Doesn't seem to break anything, but seems worth the little fix.