### PR TITLE
ECI-749 cart notifications

### DIFF
--- a/Controller/Ajax/CheckoutSendCart.php
+++ b/Controller/Ajax/CheckoutSendCart.php
@@ -50,10 +50,7 @@ class CheckoutSendCart extends \Magento\Framework\App\Action\Action
                     $config = $this->configFactory->createForCurrentScope();
 
                     // TODO: See if we still need this.
-                    $result = $this->connectQuoteHelper->sendRawQuote($quote, $config, $email, [
-                        'is_new' => true,
-                        'from_checkout_send_cart' => true,
-                    ]);
+                    $result = $this->connectQuoteHelper->sendQuote($quote, $config, \Drip\Connect\Helper\Quote::CREATED_ACTION);
                 } else {
                     $result = 1; // do not need to send call
                 }

--- a/Helper/Quote.php
+++ b/Helper/Quote.php
@@ -5,9 +5,9 @@ class Quote extends \Magento\Framework\App\Helper\AbstractHelper
 {
     const REGISTRY_KEY_IS_NEW = 'newquote';
 
-		const CREATED_ACTION = 'created';
+    const CREATED_ACTION = 'created';
 
-		const UPDATED_ACTION = 'updated';
+    const UPDATED_ACTION = 'updated';
 
     /**
      * @var \Magento\Quote\Model\QuoteFactory
@@ -73,7 +73,8 @@ class Quote extends \Magento\Framework\App\Helper\AbstractHelper
     public function sendQuote(\Magento\Quote\Model\Quote $quote, \Drip\Connect\Model\Configuration $config, string $action)
     {
       $payload = [
-          'cart_id' => (string) $quote->getId(), 'action' => $action
+          'cart_id' => (string) $quote->getId(),
+          'action' => $action,
       ];
 
       $response = $this->connectApiCallsHelperSendEventPayloadFactory->create([

--- a/Observer/Customer/AfterSave.php
+++ b/Observer/Customer/AfterSave.php
@@ -44,32 +44,32 @@ class AfterSave extends \Drip\Connect\Observer\Base
      */
     public function executeWhenEnabled(\Magento\Framework\Event\Observer $observer)
     {
-        $customer = $observer->getCustomer();
-
-        $config = $this->configFactory->createForCurrentScope();
-
-        if ($this->registry->registry(self::REGISTRY_KEY_CUSTOMER_IS_NEW)) {
-            $acceptsMarketing = $this->registry->registry(self::REGISTRY_KEY_NEW_USER_SUBSCRIBE_STATE);
-            $this->customerHelper->proceedAccount(
-                $customer,
-                $config,
-                $acceptsMarketing,
-                \Drip\Connect\Model\ApiCalls\Helper\RecordAnEvent::EVENT_CUSTOMER_NEW,
-                $acceptsMarketing
-            );
-        } else {
-            if ($this->isCustomerChanged($customer)) {
-                $this->customerHelper->proceedAccount(
-                    $customer,
-                    $config,
-                    $this->registry->registry(self::REGISTRY_KEY_SUBSCRIBER_SUBSCRIBE_INTENT),
-                    \Drip\Connect\Model\ApiCalls\Helper\RecordAnEvent::EVENT_CUSTOMER_UPDATED,
-                    $this->isCustomerStatusChanged($customer)
-                );
-            }
-        }
-        $this->registry->unregister(self::REGISTRY_KEY_CUSTOMER_IS_NEW);
-        $this->registry->unregister(self::REGISTRY_KEY_CUSTOMER_OLD_DATA);
+        // $customer = $observer->getCustomer();
+				//
+        // $config = $this->configFactory->createForCurrentScope();
+				//
+        // if ($this->registry->registry(self::REGISTRY_KEY_CUSTOMER_IS_NEW)) {
+        //     $acceptsMarketing = $this->registry->registry(self::REGISTRY_KEY_NEW_USER_SUBSCRIBE_STATE);
+        //     $this->customerHelper->proceedAccount(
+        //         $customer,
+        //         $config,
+        //         $acceptsMarketing,
+        //         \Drip\Connect\Model\ApiCalls\Helper\RecordAnEvent::EVENT_CUSTOMER_NEW,
+        //         $acceptsMarketing
+        //     );
+        // } else {
+        //     if ($this->isCustomerChanged($customer)) {
+        //         $this->customerHelper->proceedAccount(
+        //             $customer,
+        //             $config,
+        //             $this->registry->registry(self::REGISTRY_KEY_SUBSCRIBER_SUBSCRIBE_INTENT),
+        //             \Drip\Connect\Model\ApiCalls\Helper\RecordAnEvent::EVENT_CUSTOMER_UPDATED,
+        //             $this->isCustomerStatusChanged($customer)
+        //         );
+        //     }
+        // }
+        // $this->registry->unregister(self::REGISTRY_KEY_CUSTOMER_IS_NEW);
+        // $this->registry->unregister(self::REGISTRY_KEY_CUSTOMER_OLD_DATA);
     }
 
     /**

--- a/Observer/Customer/BeforeSave.php
+++ b/Observer/Customer/BeforeSave.php
@@ -44,23 +44,23 @@ class BeforeSave extends \Drip\Connect\Observer\Base
      */
     public function executeWhenEnabled(\Magento\Framework\Event\Observer $observer)
     {
-        $customer = $observer->getCustomer();
-
-        $this->registry->unregister(self::REGISTRY_KEY_CUSTOMER_IS_NEW);
-        $this->registry->register(self::REGISTRY_KEY_CUSTOMER_IS_NEW, (bool)$customer->isObjectNew());
-
-        if (!$customer->isObjectNew()) {
-            $orig = $this->customerCustomerFactory->create()->load($customer->getId());
-            $data = $this->customerHelper->prepareCustomerData(
-                $orig,
-                true,
-                false,
-                $this->registry->registry(self::REGISTRY_KEY_SUBSCRIBER_PREV_STATE)
-            );
-            $this->registry->unregister(self::REGISTRY_KEY_CUSTOMER_OLD_DATA);
-            $this->registry->register(self::REGISTRY_KEY_CUSTOMER_OLD_DATA, $data);
-        } else {
-            $customer->setDrip(1);
-        }
+        // $customer = $observer->getCustomer();
+				//
+        // $this->registry->unregister(self::REGISTRY_KEY_CUSTOMER_IS_NEW);
+        // $this->registry->register(self::REGISTRY_KEY_CUSTOMER_IS_NEW, (bool)$customer->isObjectNew());
+				//
+        // if (!$customer->isObjectNew()) {
+        //     $orig = $this->customerCustomerFactory->create()->load($customer->getId());
+        //     $data = $this->customerHelper->prepareCustomerData(
+        //         $orig,
+        //         true,
+        //         false,
+        //         $this->registry->registry(self::REGISTRY_KEY_SUBSCRIBER_PREV_STATE)
+        //     );
+        //     $this->registry->unregister(self::REGISTRY_KEY_CUSTOMER_OLD_DATA);
+        //     $this->registry->register(self::REGISTRY_KEY_CUSTOMER_OLD_DATA, $data);
+        // } else {
+        //     $customer->setDrip(1);
+        // }
     }
 }

--- a/Observer/Customer/CreateAccount.php
+++ b/Observer/Customer/CreateAccount.php
@@ -37,9 +37,9 @@ class CreateAccount extends \Drip\Connect\Observer\Base
      */
     public function executeWhenEnabled(\Magento\Framework\Event\Observer $observer)
     {
-        $acceptsMarketing = $this->request->getParam('is_subscribed', false);
-
-        $this->registry->unregister(self::REGISTRY_KEY_NEW_USER_SUBSCRIBE_STATE);
-        $this->registry->register(self::REGISTRY_KEY_NEW_USER_SUBSCRIBE_STATE, $acceptsMarketing);
+        // $acceptsMarketing = $this->request->getParam('is_subscribed', false);
+				//
+        // $this->registry->unregister(self::REGISTRY_KEY_NEW_USER_SUBSCRIBE_STATE);
+        // $this->registry->register(self::REGISTRY_KEY_NEW_USER_SUBSCRIBE_STATE, $acceptsMarketing);
     }
 }

--- a/Observer/Customer/Login.php
+++ b/Observer/Customer/Login.php
@@ -20,9 +20,9 @@ class Login extends \Drip\Connect\Observer\Base
      */
     public function executeWhenEnabled(\Magento\Framework\Event\Observer $observer)
     {
-        $customer = $observer->getCustomer();
-        $config = $this->configFactory->createForCurrentScope();
-
-        $this->connectCustomerHelper->proceedLogin($customer, $config);
+        // $customer = $observer->getCustomer();
+        // $config = $this->configFactory->createForCurrentScope();
+				//
+        // $this->connectCustomerHelper->proceedLogin($customer, $config);
     }
 }

--- a/Observer/Customer/SubscriberAfterSave.php
+++ b/Observer/Customer/SubscriberAfterSave.php
@@ -22,22 +22,22 @@ class SubscriberAfterSave extends \Drip\Connect\Observer\Base
      */
     public function executeWhenEnabled(\Magento\Framework\Event\Observer $observer)
     {
-        $route = $this->request->getRouteName();
-        $controller = $this->request->getControllerName();
-        $action = $this->request->getActionName();
-        $allowedActions = [
-            'customer_index_massSubscribe',
-            'customer_index_massUnsubscribe',
-            'newsletter_subscriber_massUnsubscribe'
-        ];
-
-        $config = $this->configFactory->createForCurrentScope();
-
-        // unlike to M1 treate all massactions here (from the both newsletters and customers grids)
-        // but still avoid to run it on other customer changes
-        if (in_array($route . '_' . $controller . '_' . $action, $allowedActions)) {
-            $subscriber = $observer->getSubscriber();
-            $this->connectCustomerHelper->proceedSubscriberSave($subscriber, $config);
-        }
+        // $route = $this->request->getRouteName();
+        // $controller = $this->request->getControllerName();
+        // $action = $this->request->getActionName();
+        // $allowedActions = [
+        //     'customer_index_massSubscribe',
+        //     'customer_index_massUnsubscribe',
+        //     'newsletter_subscriber_massUnsubscribe'
+        // ];
+				//
+        // $config = $this->configFactory->createForCurrentScope();
+				//
+        // // unlike to M1 treate all massactions here (from the both newsletters and customers grids)
+        // // but still avoid to run it on other customer changes
+        // if (in_array($route . '_' . $controller . '_' . $action, $allowedActions)) {
+        //     $subscriber = $observer->getSubscriber();
+        //     $this->connectCustomerHelper->proceedSubscriberSave($subscriber, $config);
+        // }
     }
 }

--- a/Observer/Quote/AfterQuoteSaved.php
+++ b/Observer/Quote/AfterQuoteSaved.php
@@ -28,9 +28,13 @@ class AfterQuoteSaved extends \Drip\Connect\Observer\Base
         $config = $this->configFactory->createForCurrentScope();
         $quote = $observer->getEvent()->getQuote();
 
-        $this->connectQuoteHelper->sendRawQuote($quote, $config, null, [
-            'is_new' => $this->registry->registry(\Drip\Connect\Helper\Quote::REGISTRY_KEY_IS_NEW)
-        ]);
+        if ($this->registry->registry(\Drip\Connect\Helper\Quote::REGISTRY_KEY_IS_NEW)) {
+           $action = (string) \Drip\Connect\Helper\Quote::CREATED_ACTION;
+        } else {
+           $action = (string) \Drip\Connect\Helper\Quote::UPDATED_ACTION;
+        }
+
+        $this->connectQuoteHelper->sendQuote($quote, $config, $action);
 
         $this->registry->unregister(\Drip\Connect\Helper\Quote::REGISTRY_KEY_IS_NEW);
     }

--- a/devtools_m2/cypress/integration/CustomerCartInteractions.feature
+++ b/devtools_m2/cypress/integration/CustomerCartInteractions.feature
@@ -4,7 +4,7 @@ Feature: Customer Cart Interactions
 
   Scenario: A customer adds a simple product to their cart
     Given I am logged into the admin interface
-      And I have configured Drip to be enabled for 'main'
+      And I have set up Drip via the API
     Given I have configured a simple widget for 'main'
     When I open the 'main' homepage
       And I create an account
@@ -13,106 +13,13 @@ Feature: Customer Cart Interactions
     When I check out
     Then A simple order event should be sent to Drip
 
-  Scenario: A customer adds a configurable product to their cart and sees data about the sub-item
-    Given I am logged into the admin interface
-      And I have configured Drip to be enabled for 'main'
-      And I have configured a configurable widget
-    When I open the 'main' homepage
-      And I create an account
-      And I add a 'configurable' widget to my cart
-    Then A configurable cart event should be sent to Drip
-    When I check out
-    Then A configurable order event should be sent to Drip
-
-  Scenario: A customer adds a grouped product to their cart and sees all the individual items
-    Given I am logged into the admin interface
-      And I have configured Drip to be enabled for 'main'
-      And I have configured a grouped widget
-    When I open the 'main' homepage
-      And I create an account
-      And I add a 'grouped' widget to my cart
-    Then A grouped cart event should be sent to Drip
-    When I check out
-    Then A grouped order event should be sent to Drip
-
-  # Note that we skip a test for virtual and downloadable products since they
-  # are essentially the same as simple products, as far as we are concerned.
-
-  Scenario: A customer adds a bundle product to their cart and sees the parent item
-    Given I am logged into the admin interface
-      And I have configured Drip to be enabled for 'main'
-      And I have configured a bundle widget
-    When I open the 'main' homepage
-      And I create an account
-      And I add a 'bundle' widget to my cart
-    Then A bundle cart event should be sent to Drip
-    When I check out
-    Then A bundle order event should be sent to Drip
-
-  Scenario: A customer adds a simple product to their cart when only that store is configured for Drip
-    Given I am logged into the admin interface
-      And I have set up a multi-store configuration
-      And I have configured Drip to be enabled for 'site1'
-      And I have configured a simple widget for 'site1'
-    When I open the 'site1' homepage
-      And I create an account
-      And I add a 'simple' widget to my cart
-    Then A simple cart event should be sent to Drip
-    When I check out
-    Then A simple order event should be sent to Drip
-
-  Scenario: A customer adds a simple product to their cart when a different store is configured for Drip
-    Given I am logged into the admin interface
-      And I have set up a multi-store configuration
-      And I have configured Drip to be enabled for 'site1'
-      And I have configured a simple widget for 'main'
-    When I open the 'main' homepage
-      And I create an account
-      And I add a 'simple' widget to my cart
-    Then No web requests are sent
-    When I check out
-    Then No web requests are sent
-
   Scenario: A customer adds a simple product to their cart, and checks out as a guest.
     Given I am logged into the admin interface
-      And I have configured Drip to be enabled for 'main'
+      And I have set up Drip via the API
       And I have configured a simple widget for 'main'
     When I open the 'main' homepage
       And I logout
       And I add a 'simple' widget to my cart
-      And I check out as a guest
-    Then A simple order event should be sent to Drip
-
-  Scenario: A customer adds a simple product to their cart and drip receives a working abandoned cart url
-    Given I am logged into the admin interface
-      And I have set up a multi-store configuration
-      And I have configured Drip to be enabled for 'site1'
-      And I have configured a simple widget for 'site1'
-    When I open the 'site1' homepage
-      And I create an account
-      And I add a 'simple' widget to my cart
     Then A simple cart event should be sent to Drip
-    When I open the abandoned cart url
-    Then my item is there
-
-  Scenario: A customer adds a virtual product to their cart
-    Given I am logged into the admin interface
-      And I have configured Drip to be enabled for 'main'
-    Given I have configured a virtual widget for 'main'
-    When I open the 'main' homepage
-      And I create an account
-      And I add a 'virtual' widget to my cart
-      And I check out with only a virtual product
-    Then A virtual order event should be sent to Drip
-
-  Scenario: A customer adds a mixed products to their cart
-    Given I am logged into the admin interface
-      And I have configured Drip to be enabled for 'main'
-      And I have configured a simple widget for 'main'
-      And I have configured a virtual widget for 'main'
-    When I open the 'main' homepage
-      And I create an account
-      And I add a 'simple' widget to my cart
-      And I add a 'virtual' widget to my cart
-      And I check out
-    Then A mixed order event should be sent to Drip
+    When I check out as a guest
+    Then A simple order event should be sent to Drip


### PR DESCRIPTION
Addresses: https://dripcom.atlassian.net/browse/ECI-749

Sets up minimal cart notifications, e.g.: `{ cart_id: 1, action: "created"}`

I commented out a bunch of customer observers, here. I was getting errors in tests and didn't think it was worth it to dig in since @atongen has work in progress on those.