### PR TITLE
ECI-804 cart url

### DIFF
--- a/Api/CartDetails.php
+++ b/Api/CartDetails.php
@@ -1,0 +1,44 @@
+<?php
+namespace Drip\Connect\Api;
+
+class CartDetails
+{
+    /** @var \Magento\Quote\Api\CartRepositoryInterface */
+    protected $cartRepository;
+
+    /**
+     * @var \Drip\Connect\Helper\Data
+    */
+    protected $connectHelper;
+
+    /**
+     * @var \Drip\Connect\Api\CartDetailsResponseFactory
+    */
+    protected $responseFactory;
+
+
+    public function __construct(
+        \Magento\Quote\Api\CartRepositoryInterface $cartRepository,
+        \Drip\Connect\Api\CartDetailsResponseFactory $responseFactory,
+        \Drip\Connect\Helper\Data $connectHelper
+    ) {
+        $this->cartRepository = $cartRepository;
+        $this->responseFactory = $responseFactory;
+				$this->connectHelper = $connectHelper;
+    }
+
+    /**
+     * GET for cart details
+     * @param string $cartId
+     * @return \Drip\Connect\Api\CartDetailsResponse
+     */
+    public function showDetails($cartId) {
+        $response = $this->responseFactory->create();
+        $quote = $this->cartRepository->get($cartId);
+        $url = $this->connectHelper->getAbandonedCartUrl($quote);
+
+        $response->setData(['cart_url' => $url]);
+
+        return $response;
+    }
+}

--- a/Api/CartDetails.php
+++ b/Api/CartDetails.php
@@ -8,12 +8,12 @@ class CartDetails
 
     /**
      * @var \Drip\Connect\Helper\Data
-    */
+     */
     protected $connectHelper;
 
     /**
      * @var \Drip\Connect\Api\CartDetailsResponseFactory
-    */
+     */
     protected $responseFactory;
 
 
@@ -24,7 +24,7 @@ class CartDetails
     ) {
         $this->cartRepository = $cartRepository;
         $this->responseFactory = $responseFactory;
-				$this->connectHelper = $connectHelper;
+        $this->connectHelper = $connectHelper;
     }
 
     /**

--- a/Api/CartDetailsResponse.php
+++ b/Api/CartDetailsResponse.php
@@ -1,0 +1,14 @@
+<?php
+namespace Drip\Connect\Api;
+
+class CartDetailsResponse  extends \Magento\Framework\DataObject
+{
+    /**
+     * Get order url
+     *
+     * @return string
+     */
+    public function getCartUrl() {
+        return $this->getData('cart_url');
+    }
+}

--- a/Api/CartDetailsResponse.php
+++ b/Api/CartDetailsResponse.php
@@ -1,7 +1,7 @@
 <?php
 namespace Drip\Connect\Api;
 
-class CartDetailsResponse  extends \Magento\Framework\DataObject
+class CartDetailsResponse extends \Magento\Framework\DataObject
 {
     /**
      * Get order url

--- a/Helper/Quote.php
+++ b/Helper/Quote.php
@@ -82,4 +82,16 @@ class Quote extends \Magento\Framework\App\Helper\AbstractHelper
           'payload' => $payload,
       ])->call();
     }
+
+    public function recreateCartFromQuote($oldQuote)
+     {
+         $quote = $this->checkoutSession->getQuote();
+
+         if ($quote->getId() !== $oldQuote->getId()) {
+             $quote->removeAllItems();
+             $quote->merge($oldQuote);
+             $quote->collectTotals()->save();
+         }
+         $this->checkoutSession->setQuoteId($quote->getId());
+     }
 }

--- a/Helper/Quote.php
+++ b/Helper/Quote.php
@@ -83,6 +83,9 @@ class Quote extends \Magento\Framework\App\Helper\AbstractHelper
       ])->call();
     }
 
+    /**
+     * @param \Magento\Quote\Api\Data\CartInterface $oldQuote
+     */
     public function recreateCartFromQuote($oldQuote)
      {
          $quote = $this->checkoutSession->getQuote();

--- a/devtools_m2/cypress/integration/RestApi.feature
+++ b/devtools_m2/cypress/integration/RestApi.feature
@@ -16,6 +16,15 @@ Feature: REST API Interactions
       And I have configured a simple widget for 'main'
     Then an authorized product details request gives the correct response
 
+  Scenario: Authorized request for cart details
+    Given I am logged into the admin interface
+      And I have set up Drip via the API
+      And I have configured a simple widget for 'main'
+      And I add a widget to my cart
+    Then an authorized cart details request gives the correct response
+    When I open the abandoned cart url
+    Then my item is there
+
   Scenario: Authorized request to set integration token
     Given I am logged into the admin interface
     Then an authorized integration request gives the correct response

--- a/devtools_m2/cypress/integration/RestApi/steps.js
+++ b/devtools_m2/cypress/integration/RestApi/steps.js
@@ -3,6 +3,15 @@ import { mockServerClient } from "mockserver-client"
 
 const Mockclient = mockServerClient("localhost", 1080);
 
+When('I add a widget to my cart', function(type) {
+  cy.route('POST', 'checkout/cart/add/**').as('addToCartRequest')
+  cy.visit("http://main.magento.localhost:3006/widget-1.html")
+
+  cy.get('#product-addtocart-button').click()
+  cy.wait('@addToCartRequest') // Make sure that the cart addition has finished before continuing.
+  self.item = "Widget 1"
+})
+
 Then('an authorized integration request with no websiteId gives the correct response', function(site) {
   cy.request({
     url: "http://main.magento.localhost:3006/rest/V1/integration/admin/token",
@@ -166,4 +175,39 @@ Then('an authorized product details request gives the correct response', functio
       expect(body.image_url).to.eq('http://main.magento.localhost:3006/media/catalog/product/my_image.png')
     })
   })
+})
+
+
+Then('an authorized cart details request gives the correct response', function() {
+  cy.request({
+    url: "http://main.magento.localhost:3006/rest/V1/integration/admin/token",
+    method: "POST",
+    body: {"username":"admin", "password":"abc1234567890"}
+  }).then((token_response) => {
+    cy.request({
+      url: "http://main.magento.localhost:3006/rest/V1/drip/cart/1",
+      method: "GET",
+      auth: {
+        bearer: token_response.body
+      }
+    }).then((response) => {
+      expect(response.status).to.eq(200)
+      const body = response.body
+      expect(body.cart_url).to.startWith("http://main.magento.localhost:3006/drip/cart/index/q/1/s/1/k/")
+      self.cart_url = body.cart_url
+    })
+  })
+})
+
+Then('I open the abandoned cart url', function(){
+  cy.log('Resetting mocks')
+  cy.wrap(Mockclient.reset())
+  // To use this step, a previous step has to fill the abandonedCartUrl property. See 'A simple cart event should be sent to Drip' for an example.
+  cy.visit(self.cart_url)
+})
+
+Then("my item is there", function(){
+
+  // To use this step, a previous step has to set the item property. See 'A simple cart event should be sent to Drip' for an example.
+  cy.contains(self.item)
 })

--- a/devtools_m2/cypress/integration/RestApi/steps.js
+++ b/devtools_m2/cypress/integration/RestApi/steps.js
@@ -122,7 +122,7 @@ Then('an authorized status request gives the correct response', function(site) {
       expect(body["account_param"]).to.eq('123456')
       expect(body["integration_token"]).to.eq('abcdefg')
       expect(body["magento_version"]).to.eq("2.3.2")
-      expect(body["plugin_version"]).to.eq("1.8.5")
+      expect(body["plugin_version"]).to.eq("1.8.6")
     })
   })
 })

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -30,4 +30,10 @@
             <resource ref="Drip::settings"/>
         </resources>
     </route>
+    <route method="GET" url="/V1/drip/cart/:cartId">
+        <service class="Drip\Connect\Api\CartDetails" method="showDetails"/>
+        <resources>
+            <resource ref="Drip::settings"/>
+        </resources>
+    </route>
 </routes>


### PR DESCRIPTION
Addresses: https://dripcom.atlassian.net/browse/ECI-804

Adds a cart details endpoint to return cart url.

`/rest/V1/drip/cart/:cartId`

returns:
`"{"cart_url":"http:\/\/main.magento.localhost:3006\/drip\/cart\/index\/q\/1\/s\/1\/k\/0206a75e6ca5726b2a08c1692584d347\/",
  "data":true,
  "empty":false}"`