### PR TITLE
Remove call to nonexistent getStoreId() on $config

### DIFF
--- a/Model/ApiCalls/Base.php
+++ b/Model/ApiCalls/Base.php
@@ -45,8 +45,6 @@ class Base extends \Drip\Connect\Model\Restapi\RestapiAbstract
 
         $this->storeManager = $storeManager;
 
-        $this->setStoreId($config->getStoreId());
-
         $this->connectHttpClientFactory = $connectHttpClientFactory;
         $this->_responseModel = \Drip\Connect\Model\ApiCalls\Response\Base::class;
 

--- a/Model/Configuration.php
+++ b/Model/Configuration.php
@@ -63,6 +63,11 @@ class Configuration
         }
     }
 
+    public function getStoreId()
+    {
+        return $this->storeId;
+    }
+
     public function getWebsiteId()
     {
         return $this->websiteId;

--- a/Model/Configuration.php
+++ b/Model/Configuration.php
@@ -63,11 +63,6 @@ class Configuration
         }
     }
 
-    public function getStoreId()
-    {
-        return $this->storeId;
-    }
-
     public function getWebsiteId()
     {
         return $this->websiteId;


### PR DESCRIPTION
Addresses: https://dripcom.atlassian.net/browse/ECI-832

We removed this method during cleanup, but apparently it's still being used:

```
[Mon Jul 13 20:49:55.733468 2020] [php7:error] [pid 24725] [client 172.40.10.156:30682] PHP Fatal error:  Uncaught Error: Call to undefined method Drip\\Connect\\Model\\Configuration::getStoreId() in /var/www/html/vendor/drip/connect/Model/ApiCalls/Base.php:45\nStack trace:\n#0 /var/www/html/vendor/magento/framework/ObjectManager/Factory/AbstractFactory.php(121): Drip\\Connect\\Model\\ApiCalls\\Base->__construct(Object(Drip\\Connect\\Logger\\Logger), Object(Magento\\Framework\\App\\Config), Object(Magento\\Framework\\App\\Config\\Storage\\Writer), Object(Magento\\Framework\\ArchiveFactory), Object(Magento\\Framework\\App\\Filesystem\\DirectoryList), Object(Magento\\Store\\Model\\StoreManager), Object(Drip\\Connect\\Model\\Http\\ClientFactory), Object(Drip\\Connect\\Model\\Configuration), '5652023/subscri...', false)\n#1 /var/www/html/vendor/magento/framework/ObjectManager/Factory/Dynamic/Developer.php(66): Magento\\Framework\\ObjectManager\\Factory\\AbstractFactory->createObject('Drip\\\\Connect\\\\Mo...', Array)\n#2 /var/www/html/vendor/magento/framework/ObjectManager/ObjectManager.php(56): Magento\\Framework\\ObjectManager\\Factory\\Dynamic\\Developer->create(' in /var/www/html/vendor/drip/connect/Model/ApiCalls/Base.php on line 45, referer: https://magento2-dev2.demo.drip.io
```

UPDATE:
* I modified this PR to simply remove call to the nonexistent `$config->getStoreId()`.
* On the magento 2 dev server, I added an empty executable file at `/usr/sbin/sendmail`. The appears to have fixed the `Something went wrong with the subscription` error message that had been showing up.