### PR TITLE
Identify as unsubscribed

### DIFF
--- a/view/frontend/templates/drip/footer_js.phtml
+++ b/view/frontend/templates/drip/footer_js.phtml
@@ -21,7 +21,8 @@
             <!-- identify Drip customer -->
             <script type="text/javascript">
             _dcq.push(["identify", {
-                email: "<?= $block->getCustomerEmail()?>"
+                email: "<?= $block->getCustomerEmail()?>",
+                drip_unknown_status: true
             }]);
             </script>
             <!-- end identify -->


### PR DESCRIPTION
Looks like we have the same issue here as in WooCommerce, where we sometimes might identify someone and subscribe them when they have not consented to subscription.