### PR TITLE
Create scopes in code a lot faster than clicking around the UI

### DIFF
--- a/devtools_m2/cypress/integration/common/admin.js
+++ b/devtools_m2/cypress/integration/common/admin.js
@@ -36,35 +36,7 @@ When('I have set up Drip via the API for {string}', function(site) {
 })
 
 Given('I have set up a multi-store configuration', function() {
-  cy.contains('All Stores').click({ force: true })
-
-  // globals.js defines window.setLocation, which is loaded async. We need to wait for this to be loaded.
-  cy.window().its('setLocation')
-
-  cy.contains('Create Website').click()
-  cy.window().its('setLocation')
-  cy.get('input[name="website[name]"]').type('site1_website')
-  cy.get('input[name="website[code]"]').type('site1_website')
-  cy.contains('Save Web Site').click()
-
-  cy.window().its('setLocation')
-  cy.get('button#add_group').click()
-  cy.window().its('setLocation')
-  cy.get('select[name="group[website_id]"]').select('site1_website')
-  cy.get('input[name="group[name]"]').type('site1_store')
-  cy.get('input[name="group[code]"]').type('site1_store')
-  cy.get('select[name="group[root_category_id]"]').select('Default Category')
-  cy.contains('Save Store').click()
-
-  cy.window().its('setLocation')
-  cy.contains('Create Store View').click()
-  cy.window().its('setLocation')
-  cy.get('select[name="store[group_id]"]').select('site1_store')
-  cy.get('input[name="store[name]"]').type('site1_store_view')
-  cy.get('input[name="store[code]"]').type('site1_store_view')
-  cy.get('select[name="store[is_active]"]').select('Enabled')
-  cy.contains('Save Store View').click()
-  cy.contains('OK').click()
+  cy.createScopes({})
 
   // cy.contains('Stores').click()
   cy.get('[data-ui-id="menu-magento-backend-stores-settings"]').within(function() {

--- a/devtools_m2/cypress/support/product_management.js
+++ b/devtools_m2/cypress/support/product_management.js
@@ -24,6 +24,16 @@ Cypress.Commands.add("createCustomer", (desc) => {
   })
 })
 
+Cypress.Commands.add("createScopes", (desc) => {
+  cy.log('Creating magento scopes')
+  const str = JSON.stringify(desc)
+  cy.exec(`echo '${str}' | ./docker_compose.sh exec -u www-data -T web bin/magento drip_testutils:createscopes`, {
+    env: {
+      DRIP_COMPOSE_ENV: 'test'
+    }
+  })
+})
+
 Cypress.Commands.add("runCron", (desc) => {
   cy.log('Running Magento Cron')
   const str = JSON.stringify(desc)

--- a/devtools_m2/php_utils/Console/Command/CreateScopesCommand.php
+++ b/devtools_m2/php_utils/Console/Command/CreateScopesCommand.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Drip\TestUtils\Console\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Utility command to create scopes in tests
+ */
+class CreateScopesCommand extends Command
+{
+    /** @var \Magento\Framework\App\State **/
+    protected $state;
+
+    /** @var Magento\Store\Model\WebsiteFactory */
+    protected $websiteFactory;
+
+    /** @var Magento\Store\Model\GroupFactory */
+    protected $groupFactory;
+
+    /** @var Magento\Store\Model\StoreFactory */
+    protected $storeFactory;
+
+    public function __construct(
+        \Magento\Framework\App\State $state,
+        \Magento\Store\Model\WebsiteFactory $websiteFactory,
+        \Magento\Store\Model\GroupFactory $groupFactory,
+        \Magento\Store\Model\StoreFactory $storeFactory
+    ) {
+        parent::__construct();
+
+        $this->state = $state;
+        $this->websiteFactory = $websiteFactory;
+        $this->groupFactory = $groupFactory;
+        $this->storeFactory = $storeFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName('drip_testutils:createscopes')->setDescription('Create scopes using JSON from stdin');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        // Some bookkeeping
+        $this->state->setAreaCode(\Magento\Framework\App\Area::AREA_FRONTEND);
+
+        $stdin = fopen('php://stdin', 'r');
+        $data = stream_get_contents($stdin);
+        $json = json_decode($data, true);
+
+        if ($json === null) {
+            throw new \UnexpectedValueException('Null JSON parse');
+        }
+
+        $website = $this->websiteFactory->create();
+        $website->setName("site1_website")->setCode("site1_website");
+        $website->save();
+
+        $storeGroup = $this->groupFactory->create();
+        $storeGroup->setName("site1_store")->setCode("site1_store")->setWebsiteId($website->getId());
+        $storeGroup->save();
+
+        $storeView = $this->storeFactory->create();
+        $storeView->setName("site1_store_view")->setCode("site1_store_view")->setGroupId($storeGroup->getId());
+        $storeView->save();
+    }
+}

--- a/devtools_m2/php_utils/etc/di.xml
+++ b/devtools_m2/php_utils/etc/di.xml
@@ -5,6 +5,7 @@
             <argument name="commands" xsi:type="array">
                 <item name="driptestutils_createproduct" xsi:type="object">Drip\TestUtils\Console\Command\CreateProductCommand</item>
                 <item name="driptestutils_createcustomer" xsi:type="object">Drip\TestUtils\Console\Command\CreateCustomerCommand</item>
+                <item name="driptestutils_createscopes" xsi:type="object">Drip\TestUtils\Console\Command\CreateScopesCommand</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
Co-authored-by: Kelly Heitz kelly.heitz@drip.com

We currently click around in the UI to create scopes. We're doing this in every test. Let's move this to code where it happens in a fraction of the time.