### PR TITLE
fix cart items for parent products

### DIFF
--- a/Helper/Quote.php
+++ b/Helper/Quote.php
@@ -72,11 +72,17 @@ class Quote extends \Magento\Framework\App\Helper\AbstractHelper
     ) {
         $items = [];
         foreach ($quote->getAllItems() as $item) {
-            $items[] = [
+            if ($item->getProduct()->getTypeId() === 'bundle' || $item->getProduct()->getTypeId() === 'configurable') {
+                continue;
+            }
+            $wooItem = [
               'item_id' => $item->getId(),
               'product_id' => $item->getProductId(),
-              'product_parent_id' => $item->getParentItemId()
             ];
+            if ($item->getParentItem()) {
+                $wooItem['product_parent_id'] = $item->getParentItem()->getProductId();
+            }
+            $items[] = $wooItem;
         }
 
         $payload = [

--- a/devtools_m2/cypress/integration/CustomerCartInteractions.feature
+++ b/devtools_m2/cypress/integration/CustomerCartInteractions.feature
@@ -11,7 +11,18 @@ Feature: Customer Cart Interactions
       And I add a 'simple' widget to my cart
     Then A simple cart event should be sent to Drip
     When I check out
-    Then A simple order event should be sent to Drip
+    Then An order event should be sent to Drip
+
+  Scenario: A customer adds a configurable product to their cart
+    Given I am logged into the admin interface
+      And I have set up Drip via the API for 'main'
+    Given I have configured a configurable widget
+    When I open the 'main' homepage
+      And I create an account
+      And I add a 'configurable' widget to my cart
+    Then A configurable cart event should be sent to Drip
+    When I check out
+    Then An order event should be sent to Drip
 
   Scenario: A customer adds a simple product to their cart, and checks out as a guest.
     Given I am logged into the admin interface
@@ -22,4 +33,4 @@ Feature: Customer Cart Interactions
       And I add a 'simple' widget to my cart
     Then A simple cart event should be sent to Drip
     When I check out as a guest
-    Then A simple order event should be sent to Drip
+    Then An order event should be sent to Drip


### PR DESCRIPTION
Updates the cart payload to set the `parent_product_id` correctly and to omit products that are included via their children.