### PR TITLE
use item id from parent

### DIFF
--- a/Helper/Quote.php
+++ b/Helper/Quote.php
@@ -71,8 +71,11 @@ class Quote extends \Magento\Framework\App\Helper\AbstractHelper
         string $action
     ) {
         $items = [];
+        $parentItems = [];
         foreach ($quote->getAllItems() as $item) {
-            if ($item->getProduct()->getTypeId() === 'bundle' || $item->getProduct()->getTypeId() === 'configurable') {
+            $product = $item->getProduct();
+            if ($product->getTypeId() === 'bundle' || $product->getTypeId() === 'configurable') {
+                $parentItems[$product->getId()] = $item->getId();
                 continue;
             }
             $wooItem = [
@@ -80,7 +83,9 @@ class Quote extends \Magento\Framework\App\Helper\AbstractHelper
               'product_id' => $item->getProductId(),
             ];
             if ($item->getParentItem()) {
-                $wooItem['product_parent_id'] = $item->getParentItem()->getProductId();
+                $parentId = $item->getParentItem()->getProductId();
+                $wooItem['product_parent_id'] = $parentId;
+                $wooItem['item_id'] = $parentItems[$parentId];
             }
             $items[] = $wooItem;
         }

--- a/devtools_m2/cypress/integration/CustomerCartInteractions/steps.js
+++ b/devtools_m2/cypress/integration/CustomerCartInteractions/steps.js
@@ -146,7 +146,7 @@ Then('A configurable cart event should be sent to Drip', function() {
       expect(body2.action).to.eq('updated')
       expect(body2.cart_id).to.eq('1')
       expect(body2.items).to.have.lengthOf(1)
-      expect(body2.items[0]['item_id']).to.eq('2')
+      expect(body2.items[0]['item_id']).to.eq('1')
       expect(body2.items[0]['product_id']).to.eq('1')
       expect(body2.items[0]['product_parent_id']).to.eq('3')
     }


### PR DESCRIPTION
Follow up to https://github.com/DripEmail/magento-m2-extension/pull/92

Cart items are still not quite right. The product ids are all set correctly, but the item ids are off.

To recap:
We build an array of items with product ids in them. We do that because the API response for the cart doesn't include that information.
Here's what we get from the API:
```
    "items": [
        {
            "item_id": 22,
            "sku": "Simple",
            "qty": 1,
            "name": "Simple",
            "price": 100,
            "product_type": "simple",
            "quote_id": "13"
        },
        {
            "item_id": 23,
            "sku": "Configurable-red",
            "qty": 1,
            "name": "Configurable",
            "price": 70,
            "product_type": "configurable",
            "quote_id": "13"
        },
        {
            "item_id": 25,
            "sku": "Group member",
            "qty": 1,
            "name": "Group member",
            "price": 50,
            "product_type": "grouped",
            "quote_id": "13"
        }
    ]
```
Here's the array we are building:
```
  "items":[
     {"item_id":"22","product_id":"1"},
     {"item_id":"24","product_id":"4","product_parent_id":"6"},
     {"item_id":"25","product_id":"9"}
  ]
```
The issue, I think, is that the API returns only visible items. Parent products are visible so it's the item with the parent, rather than their children, that get returned.

We are using the item id from the invisible child-item. In this example, there is no item returned from the API with id "24". So we end up with this error: https://app.honeybadger.io/projects/67590/faults/66205518
