### PR TITLE
ECI-867 Ensure pre_save_status is always an integer with cast

### DIFF
--- a/Helper/Customer.php
+++ b/Helper/Customer.php
@@ -122,7 +122,7 @@ class Customer extends \Magento\Framework\App\Helper\AbstractHelper
             'subject' => 'subscriber',
             'email' => $subscriber->getEmail(),
             'action' => $action,
-            'pre_save_status' => $preSaveStatus,
+            'pre_save_status' => (int)$preSaveStatus,
             'status' => $subscriber->getStatus()
         ];
 

--- a/devtools_m2/cypress/integration/common/admin.js
+++ b/devtools_m2/cypress/integration/common/admin.js
@@ -51,9 +51,6 @@ Given('I have set up a multi-store configuration', function() {
     path: "web/unsecure/base_link_url",
     value: "http://site1.magento.localhost:3006/",
   })
-
-  // TODO: Don't think this helps.
-  cy.flushCaches()
 })
 
 Given('I have configured Drip to be enabled for {string}', function(site) {


### PR DESCRIPTION
If the pre_save_status was the default of -3, it was coming across as an integer, however when storing an initial status in the registry and retrieving it later as in normal use, those values were coming across as strings.

This casts whatever we have for the pre save status to an integer when building the payload.

I had a difficult time writing a reasonable test for this and so didn't include one here, because the test suites are all creating a new customer and so use the default initial status is always used. However, I also ran it with the default value set to a string value and confirmed it handled that as desired.

Also removed the flush cache in multi-store-config setup bc I was tired of waiting for it and my tiny little change looked lonely.