### PR TITLE
[ECI-850] Route requests to custom domain

### DIFF
--- a/Model/ApiCalls/Helper/SendEventPayload.php
+++ b/Model/ApiCalls/Helper/SendEventPayload.php
@@ -35,7 +35,7 @@ class SendEventPayload extends \Drip\Connect\Model\ApiCalls\Helper
     {
         $accountId = $this->config->getAccountParam();
         $integrationParam = $this->config->getIntegrationToken();
-        $endpoint = "https://dfol6w1g6b.execute-api.us-east-1.amazonaws.com/v1";
+        $endpoint = "https://external-production.woo.drip.sh";
 
         if ($this->config->getTestMode()) {
             $endpoint = "http://mock:1080";


### PR DESCRIPTION
Addresses [ECI-850](https://dripcom.atlassian.net/browse/ECI-850)

The custom domains for the WIS API GW have been created in both staging and production. This will switch us over to using those URLs now.

```
https://external-production.woo.drip.sh/{account_param}/integrations/{integration_token}/events
https://external-staging.woo.drip.sh/{account_param}/integrations/{integration_token}/events
```