### PR TITLE
Clean up request IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Magento 2 Drip Connect Changelog
 
 ## Next to release
-* Changed default domain for Drip integration service 
+
+* Changed default domain for Drip integration service
+* Clarify request ID headers
 
 ## 2.0.0-beta1 (Unreleased)
 

--- a/Model/ApiCalls/Helper/SendEventPayload.php
+++ b/Model/ApiCalls/Helper/SendEventPayload.php
@@ -14,12 +14,9 @@ class SendEventPayload extends \Drip\Connect\Model\ApiCalls\Helper
         \Drip\Connect\Model\ApiCalls\WooBaseFactory $connectApiCallsWooBaseFactory,
         \Drip\Connect\Model\ApiCalls\Request\BaseFactory $connectApiCallsRequestBaseFactory,
         \Drip\Connect\Model\Configuration $config,
-        \Drip\Connect\Model\Http\RequestIDFactory $requestIdFactory,
         array $payload
     ) {
         $this->config = $config;
-
-        $payload['request_id'] = $requestIdFactory->create()->requestId();
 
         $this->apiClient = $connectApiCallsWooBaseFactory->create([
             'config' => $config,


### PR DESCRIPTION
Realized that we have two different things which are both called request ID, but have different meanings. Also, one mutates the payload while the other is a header.

Settle on a header for both, and disambiguate naming.