### PR TITLE
ECI-961-improve-migration-ux

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -43,6 +43,13 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
             </group>
+            <group id="drip_actions" sortOrder="1000" showInDefault="1" showInWebsite="0" showInStore="0" translate="label">
+                <label>Drip Actions</label>
+                <field id="sync" translate="label" type="link" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Sync All Customers or Orders</label>
+                    <comment>Sync historical data and check connection status from your Drip account.</comment>
+                </field>
+            </group>
         </section>
     </system>
 </config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -11,6 +11,9 @@
                 <integration_token></integration_token>
                 <test_mode>0</test_mode>
             </api_settings>
+            <drip_actions>
+                <sync>https://getdrip.com/integrations/magento</sync>
+            </drip_actions>
         </dripconnect_general>
     </default>
 </config>


### PR DESCRIPTION
Adds "Drip Actions" section to admin config, which directs user to getdrip.com/integrations/magento for syncing and checking the connection status of the integration. 

We might eventually want to make this more dynamic, but for now this at least gives users migrating from the first plugin the section they expect and the link to find that functionality in drip.

<img width="820" alt="Screen Shot 2020-10-15 at 4 00 23 PM" src="https://user-images.githubusercontent.com/8959469/96185549-abff0b80-0eff-11eb-931a-6042d79aadce.png">
