### PR TITLE
fix customerData.reload, first parameter should be an array

### DIFF
--- a/view/frontend/web/js/identification.js
+++ b/view/frontend/web/js/identification.js
@@ -17,7 +17,7 @@ define([
 
     // This data is cached in localstorage. It may have changed, so refetch if we don't have it.
     if (typeof (email) === "undefined") {
-      customerData.reload("customer").then(function() {
+      customerData.reload(["customer"]).then(function() {
         email = customerData.get("customer")().email;
         identifyCustomer(email);
       });


### PR DESCRIPTION
Magento_Customer/view/frontend/web/js/customer-data.js


```
/**
* @param {Array} sectionNames
* @param {Boolean} forceNewSectionTimestamp
* @return {*}
*/
reload: function (sectionNames, forceNewSectionTimestamp)
```

The "sectionNames" parameter should always be an array