### PR TITLE
Update version for 2.0.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * Add changelog here.
 
+## 2.0.6
+
+* In extension's endpoint (drip/product/:id) fetch configurable product image url when child products don't have one assigned
+
 ## 2.0.5
 
 * Proper ACL configuration to setup access to the drip_connect resource

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "drip/connect",
     "description": "Connects your M2 store to drip",
     "type": "magento2-module",
-    "version": "2.0.5",
+    "version": "2.0.6",
     "homepage": "https://github.com/DripEmail/magento-m2-extension",
     "license": [
         "OSL-3.0"

--- a/devtools_m2/cypress/integration/RestApi/steps.js
+++ b/devtools_m2/cypress/integration/RestApi/steps.js
@@ -122,7 +122,7 @@ Then('an authorized status request gives the correct response', function(site) {
       expect(body["account_param"]).to.eq('123456')
       expect(body["integration_token"]).to.eq('abcdefg')
       expect(body["magento_version"]).to.eq("2.4.5")
-      expect(body["plugin_version"]).to.eq("2.0.5")
+      expect(body["plugin_version"]).to.eq("2.0.6")
     })
   })
 })

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Drip_Connect" setup_version="2.0.5">
+    <module name="Drip_Connect" setup_version="2.0.6">
         <sequence/>
     </module>
 </config>


### PR DESCRIPTION
## TL;DR

Update extension's version for 2.0.6 release

## Context

In previous versions image URLs for child products were not automatically fetched from their parent products in the Drip endpoint. To address this, we have implemented a new image URL verifier that checks if there is no image assigned to a child product, and fetches the image from its parent if available.